### PR TITLE
refactor: simplify runs query

### DIFF
--- a/gin/runs.go
+++ b/gin/runs.go
@@ -37,7 +37,7 @@ func RunsHandler(db RunGetter) gin.HandlerFunc {
 
 		runs, err := db.Runs(filter)
 
-		if errors.As(err, &mongo.PageOutOfBoundsError{}) || errors.As(err, &mongo.NoResultsError{}) {
+		if errors.As(err, &mongo.PageOutOfBoundsError{}) {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err.Error()})
 			return
 		}

--- a/gin/samples.go
+++ b/gin/samples.go
@@ -50,7 +50,7 @@ func SamplesHandler(db SampleGetter) gin.HandlerFunc {
 			c.JSON(http.StatusOK, samples)
 			return
 		}
-		if errors.As(err, &mongo.PageOutOfBoundsError{}) || errors.As(err, &mongo.NoResultsError{}) {
+		if errors.As(err, &mongo.PageOutOfBoundsError{}) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 			return
 		}

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -10,9 +10,3 @@ type PageOutOfBoundsError struct {
 func (e PageOutOfBoundsError) Error() string {
 	return fmt.Sprintf("invalid page number %d for a result of total %d pages", e.page, e.totalPages)
 }
-
-type NoResultsError struct{}
-
-func (e NoResultsError) Error() string {
-	return "no results found"
-}

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -206,13 +206,15 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 		if err != nil {
 			return cleve.RunResult{}, err
 		}
-		if r.PaginationMetadata.TotalCount == 0 {
-			return r, NoResultsError{}
+		if r.TotalCount == 0 {
+			// No results found. Represent this as a single page
+			// with an empty slice of runs.
+			r.TotalPages = 1
 		}
-		if r.PaginationMetadata.Page > r.PaginationMetadata.TotalPages {
+		if r.Page > r.TotalPages {
 			return r, PageOutOfBoundsError{
-				page:       r.PaginationMetadata.Page,
-				totalPages: r.PaginationMetadata.TotalPages,
+				page:       r.Page,
+				totalPages: r.TotalPages,
 			}
 		}
 		return r, nil

--- a/mongo/samples.go
+++ b/mongo/samples.go
@@ -130,7 +130,9 @@ func (db DB) Samples(filter *cleve.SampleFilter) (*cleve.SampleResult, error) {
 			return &sampleResult, err
 		}
 		if sampleResult.TotalCount == 0 {
-			return &sampleResult, NoResultsError{}
+			// No results found. Represent this as a single page
+			// with an empty slice of samples.
+			sampleResult.TotalPages = 1
 		}
 		if sampleResult.Page > sampleResult.TotalPages {
 			return &sampleResult, PageOutOfBoundsError{


### PR DESCRIPTION
This PR simplifies the runs query in a similar way the samples query was implemented by applying the filters only once.

In addition, the error handling is made a bit better. Now there is a custom error for when the requested page is out of bounds. If a filter results in no data, the number of pages is set to 1, and an empty slice of runs/samples is returned. I think this makes more sense than to return a 404 (as seen in 924b4bc) since it can be a perfectly valid result, and in some cases even expected.