### PR TITLE
fix: correct filtering for QC data

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -62,10 +62,10 @@ func (f RunFilter) UrlParams() string {
 
 // QC filtering.
 type QcFilter struct {
-	RunID     string
-	Platform  string
-	StartDate time.Time
-	EndDate   time.Time
+	RunIdQuery string    `form:"run_id_query"`
+	Platform   string    `form:"platform"`
+	StartDate  time.Time `form:"start_time"`
+	EndDate    time.Time `form:"end_time"`
 	PaginationFilter
 }
 
@@ -73,8 +73,8 @@ func (f QcFilter) UrlParams() string {
 	s := "?"
 	sep := ""
 
-	if f.RunID != "" {
-		s = fmt.Sprintf("%s%srun_id=%s", s, sep, f.RunID)
+	if f.RunIdQuery != "" {
+		s = fmt.Sprintf("%s%srun_id_query=%s", s, sep, f.RunIdQuery)
 		sep = "&"
 	}
 

--- a/mongo/run_qc.go
+++ b/mongo/run_qc.go
@@ -45,13 +45,13 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 	}
 
 	// Run ID filter
-	if filter.RunID != "" {
+	if filter.RunIdQuery != "" {
 		runIdFilter := bson.D{
 			{Key: "$match", Value: bson.D{
 				{Key: "$expr", Value: bson.D{
 					{Key: "$regexMatch", Value: bson.M{
 						"input":   "$run_id",
-						"regex":   filter.RunID,
+						"regex":   filter.RunIdQuery,
 						"options": "i",
 					}},
 				}},

--- a/templates/qc.tmpl
+++ b/templates/qc.tmpl
@@ -10,7 +10,7 @@
         autocomplete="off"
         hx-get="/qc/charts/global"
         hx-target="#chart-container"
-        hx-trigger="change, keyup delay:300ms from:input[name=run_id], change from:select[name=platform]"
+        hx-trigger="change, keyup delay:300ms from:input[name=run_id_query], change from:select[name=platform]"
         hx-swap="innerHtml ignoreTitle:true"
         hx-include="#qc-table-form">
         <label for="chart-data-select">Chart type:</label>

--- a/templates/qc_table.tmpl
+++ b/templates/qc_table.tmpl
@@ -52,7 +52,7 @@
 
     <form id="qc-table-form"
         hx-get="/qc"
-        hx-trigger="keyup delay:300ms from:input[name=run_id], change from:select[name=platform]"
+        hx-trigger="keyup delay:300ms from:input[name=run_id_query], change from:select[name=platform]"
         hx-select="#qc-table-body"
         hx-target="#qc-table-body"
         hx-select-oob="#table-counts,#table-nav"
@@ -72,7 +72,7 @@
                     <th>Cycle 1 intensity</th>
                 </tr>
                 <tr>
-                    <th><input class="w-full border border-slate-300" type="text" name="run_id" placeholder="Run ID filter" value="{{ $filter.RunID }}"></input></th>
+                    <th><input class="w-full border border-slate-300" type="text" name="run_id_query" placeholder="Run ID filter" value="{{ $filter.RunIdQuery }}"></input></th>
                     <th></th>
                     <th>
                         <select name="platform">


### PR DESCRIPTION
This PR addresses an issue where the QC queries did not use the correct filtering parameters given the previous update for the runs (#28).