### PR TITLE
fix: better handling of errors in table pagination

### DIFF
--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -38,8 +38,14 @@ func DashboardHandler(db *mongo.DB) gin.HandlerFunc {
 		dashboardData, err := getDashboardData(db, filter)
 		dashboardData["version"] = cleve.GetVersion()
 
+		var oobError mongo.PageOutOfBoundsError
+		if errors.As(err, &oobError) {
+			c.HTML(http.StatusNotFound, "error404", gin.H{"error": oobError})
+			return
+		}
 		if err != nil {
 			c.HTML(http.StatusInternalServerError, "error500", dashboardData)
+			return
 		}
 
 		c.Header("Hx-Push-Url", filter.UrlParams())
@@ -95,8 +101,14 @@ func DashboardRunTable(db *mongo.DB) gin.HandlerFunc {
 		}
 
 		dashboardData, err := getDashboardData(db, filter)
+		var oobError mongo.PageOutOfBoundsError
+		if errors.As(err, &oobError) {
+			c.HTML(http.StatusNotFound, "error404", dashboardData)
+			return
+		}
 		if err != nil {
 			c.HTML(http.StatusInternalServerError, "error500", dashboardData)
+			return
 		}
 
 		c.Header("Hx-Push-Url", filter.UrlParams())

--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -113,6 +114,11 @@ func DashboardQCHandler(db *mongo.DB) gin.HandlerFunc {
 		}
 
 		qc, err := db.RunQCs(filter)
+		var oobError mongo.PageOutOfBoundsError
+		if errors.As(err, &oobError) {
+			c.HTML(http.StatusNotFound, "error404", gin.H{"error": oobError.Error()})
+			return
+		}
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/mongo/run_qc.go
+++ b/mongo/run_qc.go
@@ -130,9 +130,19 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 	}
 
 	if cursor.Next(context.TODO()) {
-		var qc cleve.QcResult
 		err = cursor.Decode(&qc)
-		return qc, err
+		if err != nil {
+			return qc, err
+		}
+		if qc.TotalCount == 0 {
+			qc.TotalPages = 1
+		}
+		if qc.Page > qc.TotalPages {
+			return qc, PageOutOfBoundsError{
+				page:       qc.Page,
+				totalPages: qc.TotalPages,
+			}
+		}
 	}
 
 	return qc, cursor.Err()

--- a/templates/error404.tmpl
+++ b/templates/error404.tmpl
@@ -1,6 +1,12 @@
 {{ define "error404" }}
 {{ template "header" }}
-<h1>Page not found</h1>
-<p>The requested document could not be found.</p>
+<h1 class="text-4xl mb-4">404 Page not found</h1>
+<p class="error my-4">
+    {{ if .error }}
+    Error: {{ .error }}
+    {{ else }}
+    The requested document could not be found.
+    {{ end }}
+</p>
 {{ template "footer" }}
 {{ end }}


### PR DESCRIPTION
Now an out-of-bounds error will generate a 404 response instead of 500, which makes more sense. In addition to this the error page shown is a bit more ergonomic than before with the error clearly stated. If the request to the underlying htmx endpoint fails, the only error displayed is in the javascript console, but this is under more control, so that should be fine for now.