### PR TITLE
ci: have the pre-commit hook edit files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,3 +9,5 @@ linters:
     - staticcheck
     - unused
     - goimports
+issues:
+  fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,4 @@ repos:
 - repo: https://github.com/TekWizely/pre-commit-golang
   rev: v1.0.0-rc.1
   hooks:
-    - id: go-fmt
     - id: golangci-lint-mod


### PR DESCRIPTION
Also skip go-fmt as gofumpt is already included with golangci-lint.