### PR TITLE
fix: bug in adding run QC via API

### DIFF
--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gmc-norr/cleve"
@@ -111,16 +110,7 @@ func AddRunQcHandler(db RunQCGetterSetter) gin.HandlerFunc {
 			return
 		}
 
-		interopPath := fmt.Sprintf("%s/InterOp", run.Path)
-		if _, err := os.Stat(interopPath); os.IsNotExist(err) {
-			ctx.AbortWithStatusJSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("interop directory not found for run %s: %s", runId, interopPath)},
-			)
-			return
-		}
-
-		qc, err := interop.InteropFromDir(interopPath)
+		qc, err := interop.InteropFromDir(run.Path)
 		if err != nil {
 			ctx.AbortWithStatusJSON(
 				http.StatusConflict,

--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -113,8 +113,8 @@ func AddRunQcHandler(db RunQCGetterSetter) gin.HandlerFunc {
 		qc, err := interop.InteropFromDir(run.Path)
 		if err != nil {
 			ctx.AbortWithStatusJSON(
-				http.StatusConflict,
-				gin.H{"error": fmt.Errorf("failed to read interop data for %s: %w", runId, err)},
+				http.StatusInternalServerError,
+				gin.H{"error": fmt.Sprintf("failed to read interop data for %s: %s", runId, err)},
 			)
 			return
 		}

--- a/interop/interop.go
+++ b/interop/interop.go
@@ -102,11 +102,11 @@ func InteropFromDir(rundir string) (Interop, error) {
 	// Mandatory files
 	i.runinfoFile, err = alternativeFile(i.dir, "RunInfo.xml")
 	if err != nil {
-		return i, err
+		return i, fmt.Errorf("failed to read RunInfo.xml: %w", err)
 	}
 	i.runparamsFile, err = alternativeFile(i.dir, "RunParameters.xml", "runParameters.xml")
 	if err != nil {
-		return i, err
+		return i, fmt.Errorf("failed to read RunParameters.xml: %w", err)
 	}
 
 	// Optional files


### PR DESCRIPTION
The wrong path was passed to the reading of the interop files, and in addition the error was malformed so it wasn't obvious what was going on. This PR addresses this issue.