### PR TITLE
fix: better status codes for various server side errors

### DIFF
--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -24,7 +24,7 @@ func NewUserMessage(text, class string) UserMessage {
 
 func getDashboardData(db *mongo.DB, filter cleve.RunFilter) (gin.H, error) {
 	runs, err := db.Runs(filter)
-	if err != nil {
+	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 		return gin.H{"error": err.Error()}, err
 	}
 
@@ -126,7 +126,7 @@ func DashboardRunTable(db *mongo.DB) gin.HandlerFunc {
 			c.HTML(http.StatusNotFound, "error404", dashboardData)
 			return
 		}
-		if err != nil {
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 			c.HTML(http.StatusInternalServerError, "error500", dashboardData)
 			return
 		}

--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -2,6 +2,7 @@ package gin
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -67,8 +68,8 @@ func DashboardRunHandler(db *mongo.DB) gin.HandlerFunc {
 		runId := c.Param("runId")
 		run, err := db.Run(runId, false)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.HTML(http.StatusNotFound, "error404", gin.H{"error": "run not found"})
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				c.HTML(http.StatusNotFound, "error404", gin.H{"error": fmt.Sprintf("run with id %q not found", runId)})
 				c.Abort()
 				return
 			}

--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -151,7 +151,7 @@ func DashboardQCHandler(db *mongo.DB) gin.HandlerFunc {
 			c.HTML(http.StatusNotFound, "error404", gin.H{"error": oobError.Error()})
 			return
 		}
-		if err != nil {
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/gin/filter.go
+++ b/gin/filter.go
@@ -26,5 +26,8 @@ func getQcFilter(c *gin.Context) (cleve.QcFilter, error) {
 	if err := c.BindQuery(&filter); err != nil {
 		return filter, err
 	}
+	if p, ok := c.Params.Get("platformName"); ok {
+		filter.Platform = p
+	}
 	return filter, filter.Validate()
 }

--- a/gin/global_charts.go
+++ b/gin/global_charts.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -18,6 +19,10 @@ func GlobalChartsHandler(db *mongo.DB) gin.HandlerFunc {
 		}
 
 		qc, err := db.RunQCs(filter)
+		if errors.Is(err, mongo.ErrNoDocuments) || qc.Count == 0 {
+			c.String(http.StatusOK, "No data to plot")
+			return
+		}
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -65,6 +65,10 @@ func AllRunQcHandler(db RunQCGetter) gin.HandlerFunc {
 			ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": oobError.Error()})
 			return
 		}
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -58,7 +58,6 @@ func AllRunQcHandler(db RunQCGetter) gin.HandlerFunc {
 			ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		filter.Platform = ctx.Param("platformName")
 
 		qc, err := db.RunQCs(filter)
 		var oobError mongo.PageOutOfBoundsError

--- a/gin/runs.go
+++ b/gin/runs.go
@@ -39,7 +39,7 @@ func RunsHandler(db RunGetter) gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err.Error()})
 			return
 		}
-		if err != nil {
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/mongo/platform.go
+++ b/mongo/platform.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gmc-norr/cleve"
 	"go.mongodb.org/mongo-driver/bson"
@@ -51,7 +52,7 @@ func (db DB) Platform(name string) (cleve.Platform, error) {
 	}
 	p, ok := platforms.Get(name)
 	if !ok {
-		return cleve.Platform{}, mongo.ErrNoDocuments
+		return cleve.Platform{}, fmt.Errorf("platform not found: %w", ErrNoDocuments)
 	}
 	return p, nil
 }

--- a/mongo/run_qc.go
+++ b/mongo/run_qc.go
@@ -48,8 +48,15 @@ func (db DB) UpdateRunQC(qc interop.InteropSummary) error {
 }
 
 func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
-	var pipeline mongo.Pipeline
-	var qc cleve.QcResult
+	var (
+		pipeline mongo.Pipeline
+		qc       cleve.QcResult
+	)
+
+	qc.PaginationMetadata = cleve.PaginationMetadata{
+		Page:     filter.Page,
+		PageSize: filter.PageSize,
+	}
 
 	pipeline = append(pipeline, bson.D{
 		{
@@ -92,7 +99,10 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 	if filter.Platform != "" {
 		platform, err := db.Platform(filter.Platform)
 		if err != nil {
-			return qc, err
+			qc.Page = 1
+			qc.TotalPages = 1
+			fmt.Printf("%+v\n", qc.PaginationMetadata)
+			return qc, fmt.Errorf("error getting platform: %w", err)
 		}
 		platformNames := append(platform.Aliases, platform.Name)
 		pipeline = append(pipeline, bson.D{
@@ -102,10 +112,6 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 		})
 	}
 
-	qc.PaginationMetadata = cleve.PaginationMetadata{
-		Page:     filter.Page,
-		PageSize: filter.PageSize,
-	}
 	metaPipeline := append(
 		pipeline,
 		bson.D{{Key: "$count", Value: "total_count"}},

--- a/mongo/run_qc.go
+++ b/mongo/run_qc.go
@@ -101,7 +101,6 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 		if err != nil {
 			qc.Page = 1
 			qc.TotalPages = 1
-			fmt.Printf("%+v\n", qc.PaginationMetadata)
 			return qc, fmt.Errorf("error getting platform: %w", err)
 		}
 		platformNames := append(platform.Aliases, platform.Name)

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -19,6 +19,7 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 		pipeline mongo.Pipeline
 	)
 
+	r.Runs = make([]*cleve.Run, 0)
 	r.PaginationMetadata = cleve.PaginationMetadata{
 		Page:     filter.Page,
 		PageSize: filter.PageSize,

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -273,7 +273,6 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 		r.Runs = append(r.Runs, &run)
 	}
 
-	fmt.Printf("%+v\n", r.PaginationMetadata)
 	if r.TotalCount == 0 {
 		// No results found. Represent this as a single page
 		// with an empty slice of runs.
@@ -301,7 +300,7 @@ func (db DB) Run(runId string, brief bool) (*cleve.Run, error) {
 	}
 
 	if runs.Count == 0 {
-		return nil, fmt.Errorf("run not found")
+		return nil, mongo.ErrNoDocuments
 	}
 	if runs.Count > 1 {
 		// We don't expect more than one matching run when filtering on run ID.

--- a/templates/error404.tmpl
+++ b/templates/error404.tmpl
@@ -1,12 +1,14 @@
 {{ define "error404" }}
 {{ template "header" }}
-<h1 class="text-4xl mb-4">404 Page not found</h1>
-<p class="error my-4">
-    {{ if .error }}
-    Error: {{ .error }}
-    {{ else }}
-    The requested document could not be found.
-    {{ end }}
-</p>
+<section class="mx-6">
+    <h1 class="text-4xl mb-4">404 Page not found</h1>
+    <p class="error my-4">
+        {{ if .error }}
+        Error: {{ .error }}
+        {{ else }}
+        The requested document could not be found.
+        {{ end }}
+    </p>
+</section>
 {{ template "footer" }}
 {{ end }}

--- a/templates/qc_table.tmpl
+++ b/templates/qc_table.tmpl
@@ -89,6 +89,9 @@
             </thead>
 
             <tbody class="border-y border-slate-500" id="qc-table-body">
+                {{ if not .qc }}
+                <tr><td colspan="10" class="text-center">No results to show</td></tr>
+                {{ end }}
                 {{ range .qc }}
                 <tr class="hover:bg-accent-100">
                     <td><a class="text-accent-900" href="/runs/{{ .RunId }}">{{ .RunId }}</a></td>

--- a/templates/qc_table.tmpl
+++ b/templates/qc_table.tmpl
@@ -2,13 +2,12 @@
 {{ $filter := .filter }}
 {{ $current_page := .metadata.Page }}
 {{ $total_pages := .metadata.TotalPages }}
-{{ $start_sample := addInt (multiplyInt (subtractInt .metadata.Page 1) .metadata.PageSize) 1 }}
 
 <section class="mx-6 mb-4 mb-8">
     <p>Here are QC data from the sequencing for runs that have completed.</p>
 
     <p id="table-counts">
-        Showing runs {{ $start_sample }} &ndash; {{ subtractInt (addInt $start_sample .metadata.Count) 1 }} of {{ .metadata.TotalCount }} runs
+        Showing {{ .metadata.Count}} of {{ .metadata.TotalCount }} runs
         Page {{ .metadata.Page }} / {{ .metadata.TotalPages }}
     </p>
 

--- a/templates/qc_table.tmpl
+++ b/templates/qc_table.tmpl
@@ -51,7 +51,7 @@
 
     <form id="qc-table-form"
         hx-get="/qc"
-        hx-trigger="keyup delay:300ms from:input[name=run_id_query], change from:select[name=platform]"
+        hx-trigger="search, keyup changed delay:300ms from:input[name=run_id_query], change from:select[name=platform]"
         hx-select="#qc-table-body"
         hx-target="#qc-table-body"
         hx-select-oob="#table-counts,#table-nav"
@@ -70,7 +70,7 @@
                     <th class="text-right">Occupied (%)</th>
                 </tr>
                 <tr>
-                    <th><input class="w-full border border-slate-300" type="text" name="run_id_query" placeholder="Run ID filter" value="{{ $filter.RunIdQuery }}"></input></th>
+                    <th><input class="w-full border border-slate-300" type="search" name="run_id_query" placeholder="Run ID filter" value="{{ $filter.RunIdQuery }}"></input></th>
                     <th></th>
                     <th>
                         <select name="platform">

--- a/templates/qc_table.tmpl
+++ b/templates/qc_table.tmpl
@@ -74,9 +74,13 @@
                     <th></th>
                     <th>
                         <select name="platform">
-                            <option value=""{{ if eq $filter.Platform "" }} selected{{ end }}>All</option>
+                            {{ $knownPlatform := false }}
+                            <option value=""{{ if eq $filter.Platform "" }} selected{{ $knownPlatform = true }}{{ end }}>All</option>
                             {{ range .platforms }}
-                            <option value="{{ . }}"{{ if eq $filter.Platform . }} selected{{ end }}>{{ . }}</option>
+                            <option value="{{ . }}"{{ if eq $filter.Platform . }} selected{{ $knownPlatform = true }}{{ end }}>{{ . }}</option>
+                            {{ end }}
+                            {{ if not $knownPlatform }}
+                            <option value="{{ $filter.Platform }}" selected>{{ $filter.Platform }}</option>
                             {{ end }}
                         </select>
                     </th>

--- a/templates/run_table.tmpl
+++ b/templates/run_table.tmpl
@@ -55,19 +55,27 @@
                     <th><input class="w-full border border-slate-300" type="search" name="run_id_query" placeholder="Filter by run ID" value="{{ .run_filter.RunIdQuery }}" /></th>
                     <th>
                         <select name="platform">
-                            <option value="" {{ if eq $run_filter.Platform "" }}selected{{ end }}>All</option>
+                            {{ $knownPlatform := false }}
+                            <option value="" {{ if eq $run_filter.Platform "" }}selected{{ $knownPlatform = true }}{{ end }}>All</option>
                             {{ range .platforms }}
-                            <option value="{{ . }}" {{ if eq $run_filter.Platform . }}selected{{ end }}>{{ . }}</option>
+                            <option value="{{ . }}" {{ if eq $run_filter.Platform . }}selected{{ $knownPlatform = true }}{{ end }}>{{ . }}</option>
+                            {{ end }}
+                            {{ if not $knownPlatform }}
+                            <option value="{{ $run_filter.Platform }}" selected>{{ $run_filter.Platform }}</option>
                             {{ end }}
                         </select>
                     <th/>
                     <th/>
                     <th>
                         <select name="state">
-                            <option value="" {{ if eq $run_filter.State "" }}selected{{ end }}>All</option>
-                            <option value="ready" {{ if eq $run_filter.State "ready" }}selected{{ end }}>Ready</option>
-                            <option value="pending" {{ if eq $run_filter.State "pending" }}selected{{ end }}>Pending</option>
-                            <option value="error" {{ if eq $run_filter.State "error" }}selected{{ end }}>Error</option>
+                            {{ $knownState := false }}
+                            <option value="" {{ if eq $run_filter.State "" }}selected{{ $knownState = true }}{{ end }}>All</option>
+                            <option value="ready" {{ if eq $run_filter.State "ready" }}selected{{ $knownState = true }}{{ end }}>Ready</option>
+                            <option value="pending" {{ if eq $run_filter.State "pending" }}selected{{ $knownState = true }}{{ end }}>Pending</option>
+                            <option value="error" {{ if eq $run_filter.State "error" }}selected{{ $knownState = true }}{{ end }}>Error</option>
+                            {{ if not $knownState }}
+                            <option value="{{ $run_filter.State }}" selected>{{ $run_filter.State }}</option>
+                            {{ end }}
                         </select>
                     </th>
                     </th>

--- a/templates/run_table.tmpl
+++ b/templates/run_table.tmpl
@@ -75,6 +75,9 @@
             </thead>
 
             <tbody class="border-y border-slate-500" id="runtable-body">
+                {{ if not .runs.Runs }}
+                <tr><td colspan="7" class="text-center">No results to show</td></tr>
+                {{ end }}
                 {{ range .runs.Runs }}
                 <tr class="hover:bg-accent-100">
                     <td><a class="text-accent-900" href="/runs/{{ .RunID }}">{{ .RunID }}</a></td>

--- a/templates/run_table.tmpl
+++ b/templates/run_table.tmpl
@@ -39,7 +39,7 @@
 </div>
 
 <div class="mx-6 mb-6 overflow-x-auto">
-    <form hx-get="/runtable" hx-target="#runtable-body" hx-select="#runtable-body" hx-swap="outerHTML" hx-trigger="keyup delay:300ms from:input[name=run_id_query], change from:select[name=platform], change from:select[name=state]" hx-select-oob="#table-counts,#table-nav">
+    <form hx-get="/runtable" hx-target="#runtable-body" hx-select="#runtable-body" hx-swap="outerHTML" hx-trigger="search, keyup changed delay:300ms from:input[name=run_id_query], change from:select[name=platform], change from:select[name=state]" hx-select-oob="#table-counts,#table-nav">
         <table class="w-full">
             <thead class="text-left">
                 <tr class="border-b border-slate-500">
@@ -52,7 +52,7 @@
                     <th>Path</th>
                 </tr>
                 <tr>
-                    <th><input class="w-full border border-slate-300" type="text" name="run_id_query" placeholder="Filter by run ID" value="{{ .run_filter.RunIdQuery }}" /></th>
+                    <th><input class="w-full border border-slate-300" type="search" name="run_id_query" placeholder="Filter by run ID" value="{{ .run_filter.RunIdQuery }}" /></th>
                     <th>
                         <select name="platform">
                             <option value="" {{ if eq $run_filter.Platform "" }}selected{{ end }}>All</option>


### PR DESCRIPTION
This PR addresses a number of issues.

- Filters that produce no runs now returns an HTTP 200 response with an empty set of items (both dashboard and API).
- Trying to access a non-existent run now properly responds with a 404 (both dashboard and API).
- Custom values for platform and status in the URL now populate the corresponding fields in the table for both runs and run QC (dashboard).
- If no QC data is returned not plotting is attempted (dashboard).
- For the QC endpoint, if the platform doesn't exist, respond with a 404 instead of a 500 (API).