### PR TITLE
feat: add handling of gene panels

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -444,6 +444,9 @@
   .bg-amber-600 {
     background-color: var(--color-amber-600);
   }
+  .bg-red-600 {
+    background-color: var(--color-red-600);
+  }
   .bg-slate-200 {
     background-color: var(--color-slate-200);
   }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -544,6 +544,9 @@
   .text-white {
     color: var(--color-white);
   }
+  .italic {
+    font-style: italic;
+  }
   .ordinal {
     --tw-ordinal: ordinal;
     font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,13 +11,23 @@
     --color-amber-600: oklch(66.6% 0.179 58.318);
     --color-yellow-400: oklch(85.2% 0.199 91.936);
     --color-green-600: oklch(62.7% 0.194 149.214);
+    --color-slate-200: oklch(92.9% 0.013 255.508);
     --color-slate-300: oklch(86.9% 0.022 252.894);
     --color-slate-500: oklch(55.4% 0.046 257.417);
+    --color-slate-600: oklch(44.6% 0.043 257.281);
+    --color-gray-200: oklch(92.8% 0.006 264.531);
     --color-gray-400: oklch(70.7% 0.022 261.325);
+    --color-gray-500: oklch(55.1% 0.027 264.364);
+    --color-gray-900: oklch(21% 0.034 264.665);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
+    --container-3xs: 16rem;
+    --container-2xs: 18rem;
     --container-lg: 32rem;
+    --container-4xl: 56rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
     --text-lg: 1.125rem;
@@ -30,8 +40,10 @@
     --text-3xl--line-height: calc(2.25 / 1.875);
     --text-4xl: 2.25rem;
     --text-4xl--line-height: calc(2.5 / 2.25);
+    --font-weight-medium: 500;
     --font-weight-bold: 700;
     --radius-md: 0.375rem;
+    --animate-spin: spin 1s linear infinite;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -262,6 +274,9 @@
   .mr-2 {
     margin-right: calc(var(--spacing) * 2);
   }
+  .mb-2 {
+    margin-bottom: calc(var(--spacing) * 2);
+  }
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
   }
@@ -273,6 +288,9 @@
   }
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
+  }
+  .block {
+    display: block;
   }
   .contents {
     display: contents;
@@ -292,6 +310,10 @@
   .table {
     display: table;
   }
+  .size-\[\.8em\] {
+    width: .8em;
+    height: .8em;
+  }
   .max-h-lvh {
     max-height: 100lvh;
   }
@@ -301,17 +323,38 @@
   .w-full {
     width: 100%;
   }
+  .max-w-4xl {
+    max-width: var(--container-4xl);
+  }
   .max-w-fit {
     max-width: fit-content;
   }
   .max-w-lg {
     max-width: var(--container-lg);
   }
+  .min-w-2xs {
+    min-width: var(--container-2xs);
+  }
+  .min-w-3xs {
+    min-width: var(--container-3xs);
+  }
   .min-w-fit {
     min-width: fit-content;
   }
+  .flex-none {
+    flex: none;
+  }
+  .table-auto {
+    table-layout: auto;
+  }
   .transform {
     transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+  }
+  .animate-spin {
+    animation: var(--animate-spin);
+  }
+  .cursor-pointer {
+    cursor: pointer;
   }
   .resize {
     resize: both;
@@ -319,17 +362,26 @@
   .list-none {
     list-style-type: none;
   }
+  .grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
   .grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
   .grid-rows-1 {
     grid-template-rows: repeat(1, minmax(0, 1fr));
   }
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
   .items-center {
     align-items: center;
   }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
+  }
+  .gap-12 {
+    gap: calc(var(--spacing) * 12);
   }
   .truncate {
     overflow: hidden;
@@ -342,10 +394,17 @@
   .overflow-y-scroll {
     overflow-y: scroll;
   }
+  .rounded-full {
+    border-radius: calc(infinity * 1px);
+  }
   .rounded-md {
     border-radius: var(--radius-md);
   }
   .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-1 {
     border-style: var(--tw-border-style);
     border-width: 1px;
   }
@@ -360,6 +419,12 @@
   .border-b {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
+  }
+  .border-gray-200 {
+    border-color: var(--color-gray-200);
+  }
+  .border-gray-500 {
+    border-color: var(--color-gray-500);
   }
   .border-slate-300 {
     border-color: var(--color-slate-300);
@@ -379,6 +444,9 @@
   .bg-amber-600 {
     background-color: var(--color-amber-600);
   }
+  .bg-slate-200 {
+    background-color: var(--color-slate-200);
+  }
   .bg-slate-500 {
     background-color: var(--color-slate-500);
   }
@@ -391,8 +459,14 @@
   .p-6 {
     padding: calc(var(--spacing) * 6);
   }
+  .px-1 {
+    padding-inline: calc(var(--spacing) * 1);
+  }
   .px-2 {
     padding-inline: calc(var(--spacing) * 2);
+  }
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
   }
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
@@ -432,19 +506,37 @@
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
   }
+  .text-sm\/6 {
+    font-size: var(--text-sm);
+    line-height: calc(var(--spacing) * 6);
+  }
   .text-xl {
     font-size: var(--text-xl);
     line-height: var(--tw-leading, var(--text-xl--line-height));
   }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
+  }
+  .font-medium {
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
   }
   .text-accent-100 {
     color: var(--color-accent-100);
   }
   .text-accent-900 {
     color: var(--color-accent-900);
+  }
+  .text-gray-900 {
+    color: var(--color-gray-900);
+  }
+  .text-slate-600 {
+    color: var(--color-slate-600);
   }
   .text-white {
     color: var(--color-white);
@@ -673,6 +765,11 @@
 @property --tw-drop-shadow-size {
   syntax: "*";
   inherits: false;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {

--- a/assets/img/spinner.svg
+++ b/assets/img/spinner.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="10" stroke="#4c1b9b55" stroke-width="4"></circle>
+    <path fill="#4c1b9b" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+    </path>
+</svg>

--- a/cleve_api.yaml
+++ b/cleve_api.yaml
@@ -410,6 +410,16 @@ endpoints:
         description: Return a specific version of a panel
         default: ""
 
+  - path: /panels/{panelId}/archive
+    method: PATCH
+    section: panels
+    description: Archive all versions of a panel
+    params:
+      - key: panelId
+        type: string
+        description: panel ID
+        required: true
+
   - path: /platforms
     method: GET
     section: platforms

--- a/cleve_api.yaml
+++ b/cleve_api.yaml
@@ -10,6 +10,8 @@ sections:
     description: Sample information.
   - name: samplesheet
     description: Samplesheet information for sequencing runs.
+  - name: panels
+    description: Information gene panels.
   - name: platforms
     description: Information on sequencing platforms.
 endpoints:
@@ -320,6 +322,49 @@ endpoints:
         type: string
         description: ID of the run
         required: true
+
+  - path: /panels
+    method: GET
+    section: panels
+    description: >
+      Get all gene panels. There are multiple versions of a panel, the most recent is returned.
+      Archived panels are ignored by default.
+    query_params:
+      - key: archived
+        type: bool
+        description: Also return archived gene panels
+        default: false
+      - key: category
+        type: string
+        description: Only return panels belonging to this category
+        default: ""
+      - key: gene
+        type: string
+        description: Only return panels that has this gene symbol on it (case insensitive)
+        default: ""
+      - key: gene_query
+        type: regex
+        description: Only return panels that has at least one gene matching a regular expression
+        default: ""
+      - key: name_query
+        type: regex
+        description: Only return panels whose name matches a regular expression
+        default: ""
+
+  - path: /panels/{panelId}
+    method: GET
+    section: panels
+    description: Get a single gene panel by ID.
+    params:
+      - key: panelId
+        type: string
+        description: panel ID
+        required: true
+    query_params:
+      - key: version
+        type: string
+        description: Return a specific version of a panel
+        default: ""
 
   - path: /platforms
     method: GET

--- a/cleve_api.yaml
+++ b/cleve_api.yaml
@@ -351,6 +351,50 @@ endpoints:
         description: Only return panels whose name matches a regular expression
         default: ""
 
+  - path: /panels
+    method: POST
+    section: panels
+    description: >
+      Create a new gene panel. The request body should be a JSON representation of the panel to
+      create.
+    headers:
+      - key: Authorization
+        type: string
+        description: API key
+        required: true
+      - key: Content-Type
+        type: string
+        description: MIME type of the request data. Currently only `application/json` is accepted.
+    params:
+      - key: id
+        type: string
+        description: ID of the panel
+        required: true
+      - key: name
+        type: string
+        description: Name of the panel
+        required: true
+      - key: version
+        type: string
+        description: The version of the panel
+        required: true
+      - key: date
+        type: string
+        description: Panel creation date. Should be connected to the version.
+        required: false
+      - key: categories
+        type: array
+        description: An array of strings with the categories to which the panel belongs
+        required: false
+      - key: description
+        type: string
+        description: Description of the panel
+        required: false
+      - key: genes
+        type: array
+        description: An array of gene objects with the mandatory key `hgnc` (string), and the optional keys `symbol` (string) and `aliases` (array of strings). At least one gene is required.
+        required: true
+
   - path: /panels/{panelId}
     method: GET
     section: panels

--- a/cmd/cleve/main.go
+++ b/cmd/cleve/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gmc-norr/cleve"
 	"github.com/gmc-norr/cleve/cmd/cleve/db"
 	"github.com/gmc-norr/cleve/cmd/cleve/key"
+	"github.com/gmc-norr/cleve/cmd/cleve/panel"
 	"github.com/gmc-norr/cleve/cmd/cleve/platform"
 	"github.com/gmc-norr/cleve/cmd/cleve/run"
 	"github.com/gmc-norr/cleve/cmd/cleve/samplesheet"
@@ -32,6 +33,7 @@ func init() {
 	rootCmd.AddCommand(run.RunCmd)
 	rootCmd.AddCommand(db.DbCmd)
 	rootCmd.AddCommand(key.KeyCmd)
+	rootCmd.AddCommand(panel.PanelCmd)
 	rootCmd.AddCommand(platform.PlatformCmd)
 	rootCmd.AddCommand(samplesheet.SampleSheetCmd)
 }

--- a/cmd/cleve/panel/add.go
+++ b/cmd/cleve/panel/add.go
@@ -82,10 +82,11 @@ over what is in the file.
 			p.Description = description
 		}
 		if date, _ := cmd.Flags().GetString("date"); date != "" {
-			p.Date, err = time.Parse("2006-01-02", date)
+			d, err := time.Parse("2006-01-02", date)
 			cobra.CheckErr(err)
+			p.Date = cleve.Time{Time: d}
 		} else if p.Date.IsZero() {
-			p.Date = time.Now()
+			p.Date = cleve.Time{Time: time.Now()}
 		}
 		if categories, _ := cmd.Flags().GetStringSlice("categories"); len(categories) != 0 {
 			for _, cat := range categories {

--- a/cmd/cleve/panel/add.go
+++ b/cmd/cleve/panel/add.go
@@ -1,7 +1,6 @@
 package panel
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -93,16 +92,16 @@ over what is in the file.
 				p.AddCategory(cat)
 			}
 		}
-		if len(p.Categories) == 0 {
-			cobra.CheckErr("at least one category is needed for the gene panel")
-		}
-
-		fmt.Printf("%#v\n", p)
+		err = p.Validate()
+		cobra.CheckErr(err)
 
 		db, err := mongo.Connect()
 		cobra.CheckErr(err)
 
 		err = db.CreatePanel(p)
+		if mongo.IsDuplicateKeyError(err) {
+			cobra.CheckErr("a panel with this id and version already exists")
+		}
 		cobra.CheckErr(err)
 	},
 }

--- a/cmd/cleve/panel/add.go
+++ b/cmd/cleve/panel/add.go
@@ -73,9 +73,13 @@ over what is in the file.
 			p.Id = strings.ToLower(p.Name)
 		}
 		if version, _ := cmd.Flags().GetString("version"); version != "" {
-			p.Version = version
-		} else if p.Version == "" {
-			p.Version = "1.0"
+			p.Version, err = cleve.ParseVersion(version)
+			cobra.CheckErr(err)
+			if p.Version.HasPatch() {
+				cobra.CheckErr("version numbers may only contain major and minor numbers")
+			}
+		} else if p.Version.IsZero() {
+			p.Version = cleve.NewMinorVersion(1, 0)
 		}
 		if description, _ := cmd.Flags().GetString("description"); description != "" {
 			p.Description = description

--- a/cmd/cleve/panel/add.go
+++ b/cmd/cleve/panel/add.go
@@ -81,11 +81,10 @@ over what is in the file.
 			p.Description = description
 		}
 		if date, _ := cmd.Flags().GetString("date"); date != "" {
-			d, err := time.Parse("2006-01-02", date)
+			p.Date, err = time.Parse("2006-01-02", date)
 			cobra.CheckErr(err)
-			p.Date = cleve.Time{Time: d}
 		} else if p.Date.IsZero() {
-			p.Date = cleve.Time{Time: time.Now()}
+			p.Date = time.Now()
 		}
 		if categories, _ := cmd.Flags().GetStringSlice("categories"); len(categories) != 0 {
 			for _, cat := range categories {

--- a/cmd/cleve/panel/add.go
+++ b/cmd/cleve/panel/add.go
@@ -1,0 +1,77 @@
+package panel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gmc-norr/cleve"
+	"github.com/spf13/cobra"
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add [flags] panel-definition",
+	Short: "Add a gene panel to the database",
+	Long: `Panels can be added from a couple of different file formats: csv, tsv.
+CSV and TSV should be semicolon-separated and tab-separated, respectively. Each
+row represents a gene and should contain the following columns:
+
+- hgnc: HGNC ID of the gene (aliases: hgnc_id)
+- symbol: The symbol to use for the gene (aliases: hgnc_symbol)
+- disease_associated_transcripts: Comma-separated list of manually curated transcripts
+- genetic_disease_models: Comma-separated list of manually curated inheritance patterns that are followed by a gene
+- mosaicism: Whether the gene is known to be associated with mosaicism
+- reduced_penetrance: Whether the gene is known to have reduced penetrance
+
+The file should contain a header line that should begin with '#'. If the header is missing
+the order of the columns must match the order given above. Metadata can also be defined
+in the header as key-value pairs: '##key=value'. Supported keys are:
+
+- id: Internal ID of the panel (aliases: panel_id)
+- name: The name of the panel (aliases: display_name)
+- version: Panel version
+- description: Free-text description of the panel
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fileType, _ := cmd.Flags().GetString("filetype")
+		f, err := os.Open(args[0])
+		cobra.CheckErr(err)
+		defer f.Close()
+
+		var (
+			parseError error
+			p          cleve.GenePanel
+		)
+		switch fileType {
+		case "tsv":
+			p, parseError = cleve.GenePanelFromTsv(f)
+		case "csv":
+			p, parseError = cleve.GenePanelFromCsv(f)
+		default:
+			cobra.CheckErr("invalid filetype, should be one of tsv, csv")
+		}
+		cobra.CheckErr(parseError)
+
+		if p.Name == "" {
+			fname := filepath.Base(f.Name())
+			stem := fname[:len(fname)-len(filepath.Ext(fname))]
+			p.Name = filepath.Base(stem)
+		}
+		if p.Id == "" {
+			p.Id = strings.ToLower(p.Name)
+		}
+		if p.Version == "" {
+			p.Version = "1.0"
+		}
+
+		fmt.Printf("%+v\n", p)
+	},
+}
+
+func init() {
+	addCmd.Flags().StringP("name", "n", "", "name of the new panel, defaults to the name of the definition file")
+	addCmd.Flags().StringP("id", "i", "", "ID for the new panel, defaults to a slug of the name of the definition file")
+	addCmd.Flags().StringP("filetype", "f", "tsv", "filetype of the panel definition file")
+}

--- a/cmd/cleve/panel/archive.go
+++ b/cmd/cleve/panel/archive.go
@@ -1,0 +1,37 @@
+package panel
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/gmc-norr/cleve/mongo"
+	"github.com/spf13/cobra"
+)
+
+var archiveCmd = &cobra.Command{
+	Use:   "archive [flags] PANEL",
+	Short: "Archive or unarchive a gene panel",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		unarchive, _ := cmd.Flags().GetBool("unarchive")
+		slog.Info("modifying panel", "id", args[0], "archive", !unarchive)
+		db, err := mongo.Connect()
+		cobra.CheckErr(err)
+		if unarchive {
+			err = db.UnarchivePanel(args[0])
+		} else {
+			err = db.ArchivePanel(args[0])
+		}
+		if err != nil {
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				cobra.CheckErr(fmt.Sprintf("panel with ID %q not found", args[0]))
+			}
+			cobra.CheckErr(err)
+		}
+	},
+}
+
+func init() {
+	archiveCmd.Flags().BoolP("unarchive", "u", false, "unarchive a panel")
+}

--- a/cmd/cleve/panel/delete.go
+++ b/cmd/cleve/panel/delete.go
@@ -1,0 +1,75 @@
+package panel
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gmc-norr/cleve/mongo"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteId      string
+	deleteVersion string
+	deleteCmd     = &cobra.Command{
+		Use:   "delete [flags] ID [VERSION]",
+		Short: "Delete panel(s)",
+		Long:  "Delete on or more panels. If VERSION is omitted, all versions with the specified ID will be deleted.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			r := bufio.NewReader(os.Stdin)
+			deleteAll := deleteVersion == ""
+			for {
+				if deleteAll {
+					fmt.Printf("this will delete all versions of %s, continue? [Y/n] ", deleteId)
+				} else {
+					fmt.Printf("this will delete version %s of %s, continue? [Y/n] ", deleteVersion, deleteId)
+				}
+				s, _ := r.ReadString('\n')
+				s = strings.TrimSpace(s)
+				s = strings.ToLower(s)
+				if s == "n" {
+					fmt.Fprintln(os.Stderr, "canceled")
+					os.Exit(0)
+					return
+				} else if s == "y" {
+					break
+				} else {
+					fmt.Fprintln(os.Stderr, "answer with Y or N")
+					continue
+				}
+			}
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+				return err
+			}
+			deleteId = args[0]
+			if err := cobra.MaximumNArgs(2)(cmd, args); err != nil {
+				return err
+			}
+			if len(args) > 1 {
+				deleteVersion = args[1]
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			db, err := mongo.Connect()
+			cobra.CheckErr(err)
+			n, err := db.DeletePanel(deleteId, deleteVersion)
+			cobra.CheckErr(err)
+			if n == 0 && deleteVersion == "" {
+				fmt.Printf("no entries found for %s\n", deleteId)
+				os.Exit(1)
+			} else if n == 0 {
+				fmt.Printf("version %s not found for %s\n", deleteVersion, deleteId)
+				os.Exit(1)
+			} else if n == 1 {
+				fmt.Printf("deleted %d entry of %s\n", n, deleteId)
+			} else {
+				fmt.Printf("deleted %d entries of %s\n", n, deleteId)
+			}
+		},
+	}
+)

--- a/cmd/cleve/panel/list.go
+++ b/cmd/cleve/panel/list.go
@@ -1,0 +1,43 @@
+package panel
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/gmc-norr/cleve"
+	"github.com/gmc-norr/cleve/mongo"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list [flags]",
+	Short: "List panels",
+	Run: func(cmd *cobra.Command, args []string) {
+		db, err := mongo.Connect()
+		cobra.CheckErr(err)
+
+		showAll, _ := cmd.Flags().GetBool("all")
+		gene, _ := cmd.Flags().GetString("gene")
+
+		filter := cleve.NewPanelFilter()
+		filter.Archived = showAll
+		filter.Gene = gene
+
+		panels, err := db.Panels(filter)
+		cobra.CheckErr(err)
+
+		w := tabwriter.NewWriter(os.Stdout, 5, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "id\tname\tversion\tarchived")
+		fmt.Fprintln(w, "--\t----\t-------\t--------")
+		for _, p := range panels {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%t\n", p.Id, p.Name, p.Version, p.Archived)
+		}
+		w.Flush()
+	},
+}
+
+func init() {
+	listCmd.Flags().BoolP("all", "a", false, "show also archived panels")
+	listCmd.Flags().StringP("gene", "g", "", "list panels containing a certain gene (symbol, case insensitive)")
+}

--- a/cmd/cleve/panel/list.go
+++ b/cmd/cleve/panel/list.go
@@ -31,7 +31,7 @@ var listCmd = &cobra.Command{
 		fmt.Fprintln(w, "id\tname\tversion\tarchived")
 		fmt.Fprintln(w, "--\t----\t-------\t--------")
 		for _, p := range panels {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%t\n", p.Id, p.Name, p.Version, p.Archived)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%t\n", p.Id, p.Name, p.Version.String(), p.Archived)
 		}
 		w.Flush()
 	},

--- a/cmd/cleve/panel/panel.go
+++ b/cmd/cleve/panel/panel.go
@@ -4,6 +4,7 @@ import "github.com/spf13/cobra"
 
 func init() {
 	PanelCmd.AddCommand(addCmd)
+	PanelCmd.AddCommand(archiveCmd)
 }
 
 var PanelCmd = &cobra.Command{

--- a/cmd/cleve/panel/panel.go
+++ b/cmd/cleve/panel/panel.go
@@ -5,6 +5,7 @@ import "github.com/spf13/cobra"
 func init() {
 	PanelCmd.AddCommand(addCmd)
 	PanelCmd.AddCommand(archiveCmd)
+	PanelCmd.AddCommand(listCmd)
 }
 
 var PanelCmd = &cobra.Command{

--- a/cmd/cleve/panel/panel.go
+++ b/cmd/cleve/panel/panel.go
@@ -1,0 +1,12 @@
+package panel
+
+import "github.com/spf13/cobra"
+
+func init() {
+	PanelCmd.AddCommand(addCmd)
+}
+
+var PanelCmd = &cobra.Command{
+	Use:   "panel",
+	Short: "Manage in-silico gene panels",
+}

--- a/cmd/cleve/panel/panel.go
+++ b/cmd/cleve/panel/panel.go
@@ -6,6 +6,7 @@ func init() {
 	PanelCmd.AddCommand(addCmd)
 	PanelCmd.AddCommand(archiveCmd)
 	PanelCmd.AddCommand(listCmd)
+	PanelCmd.AddCommand(deleteCmd)
 }
 
 var PanelCmd = &cobra.Command{

--- a/embed.go
+++ b/embed.go
@@ -26,13 +26,13 @@ func GetAPIDoc() []byte {
 
 //go:generate sh -c "git describe --tags > version.txt || printf '' > version.txt"
 //go:embed version.txt
-var Version string
-var LastRelease string = "v0.4.3" // x-release-please-version
+var version string
+var lastRelease string = "v0.4.3" // x-release-please-version
 
 func GetVersion() string {
-	v := strings.TrimSpace(Version)
+	v := strings.TrimSpace(version)
 	if v == "" {
-		return LastRelease
+		return lastRelease
 	}
 	return v
 }

--- a/filters.go
+++ b/filters.go
@@ -166,12 +166,12 @@ func (f SampleFilter) UrlParams() string {
 type PanelFilter struct {
 	Category  string `form:"category"`
 	Name      string `form:"name"`
-	NameQuery string `form:"name-query"`
+	NameQuery string `form:"name_query"`
 	Gene      string `form:"gene"`
-	GeneQuery string `form:"gene-query"`
+	GeneQuery string `form:"gene_query"`
 	HGNC      string `form:"hgnc"`
 	Version   string `form:"version"`
-	Archived  bool
+	Archived  bool   `form:"archived"`
 }
 
 func NewPanelFilter() PanelFilter {

--- a/filters.go
+++ b/filters.go
@@ -162,3 +162,18 @@ func (f SampleFilter) UrlParams() string {
 
 	return p
 }
+
+type PanelFilter struct {
+	Category  string `form:"category"`
+	Name      string `form:"name"`
+	NameQuery string `form:"name-query"`
+	Gene      string `form:"gene"`
+	GeneQuery string `form:"gene-query"`
+	HGNC      string `form:"hgnc"`
+	Version   string `form:"version"`
+	Archived  bool
+}
+
+func NewPanelFilter() PanelFilter {
+	return PanelFilter{}
+}

--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -34,7 +34,7 @@ func getDashboardData(db *mongo.DB, filter cleve.RunFilter) (gin.H, error) {
 	}
 	platformNames := platforms.Names()
 
-	return gin.H{"runs": runs.Runs, "metadata": runs.PaginationMetadata, "platforms": platformNames, "filter": filter}, nil
+	return gin.H{"runs": runs.Runs, "metadata": runs.PaginationMetadata, "platforms": platformNames, "filter": filter, "cleve_version": cleve.GetVersion()}, nil
 }
 
 func DashboardHandler(db *mongo.DB) gin.HandlerFunc {
@@ -50,7 +50,6 @@ func DashboardHandler(db *mongo.DB) gin.HandlerFunc {
 			c.HTML(http.StatusInternalServerError, "error500", gin.H{"error": err})
 			return
 		}
-		dashboardData["version"] = cleve.GetVersion()
 
 		var oobError mongo.PageOutOfBoundsError
 		if errors.As(err, &oobError) {
@@ -108,7 +107,7 @@ func DashboardRunHandler(db *mongo.DB) gin.HandlerFunc {
 			}
 		}
 
-		c.HTML(http.StatusOK, "run", gin.H{"run": run, "qc": qc, "hasQc": hasQc, "samplesheet": sampleSheet, "chart_config": GetRunChartConfig(c), "version": cleve.GetVersion(), "message": message})
+		c.HTML(http.StatusOK, "run", gin.H{"run": run, "qc": qc, "hasQc": hasQc, "samplesheet": sampleSheet, "chart_config": GetRunChartConfig(c), "cleve_version": cleve.GetVersion(), "message": message})
 	}
 }
 
@@ -164,6 +163,6 @@ func DashboardQCHandler(db *mongo.DB) gin.HandlerFunc {
 		platformNames := platforms.Names()
 
 		c.Header("Hx-Push-Url", filter.UrlParams())
-		c.HTML(http.StatusOK, "qc", gin.H{"qc": qc.InteropSummary, "metadata": qc.PaginationMetadata, "platforms": platformNames, "filter": filter, "chart_config": chartConfig, "version": cleve.GetVersion()})
+		c.HTML(http.StatusOK, "qc", gin.H{"qc": qc.InteropSummary, "metadata": qc.PaginationMetadata, "platforms": platformNames, "filter": filter, "chart_config": chartConfig, "cleve_version": cleve.GetVersion()})
 	}
 }

--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -135,7 +135,7 @@ func DashboardPanelHandler(db *mongo.DB) gin.HandlerFunc {
 			}
 			d["versions"] = versions
 			if filter.Version == "" {
-				filter.Version = versions[0].Version
+				filter.Version = versions[0].Version.String()
 				d["version"] = filter.Version
 			}
 

--- a/gin/filter.go
+++ b/gin/filter.go
@@ -31,3 +31,11 @@ func getQcFilter(c *gin.Context) (cleve.QcFilter, error) {
 	}
 	return filter, filter.Validate()
 }
+
+func getPanelFilter(c *gin.Context) (cleve.PanelFilter, error) {
+	filter := cleve.NewPanelFilter()
+	if err := c.BindQuery(&filter); err != nil {
+		return filter, err
+	}
+	return filter, nil
+}

--- a/gin/panels.go
+++ b/gin/panels.go
@@ -1,0 +1,59 @@
+package gin
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gmc-norr/cleve/mongo"
+)
+
+func PanelsHandler(db *mongo.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		filter, err := getPanelFilter(c)
+		if err != nil {
+			c.AbortWithStatusJSON(
+				http.StatusInternalServerError,
+				gin.H{"error": err},
+			)
+			return
+		}
+		slog.Info("api panels", "filter", filter)
+		panels, err := db.Panels(filter)
+		if err != nil {
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				c.JSON(http.StatusOK, panels)
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err})
+			return
+		}
+		c.JSON(http.StatusOK, panels)
+	}
+}
+
+func PanelHandler(db *mongo.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		panelId := c.Param("panelId")
+		filter, err := getPanelFilter(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		panel, err := db.Panel(panelId, filter.Version)
+		if err != nil {
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+					"error":   "panel not found",
+					"id":      panelId,
+					"version": filter.Version,
+				})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, panel)
+	}
+}

--- a/gin/panels.go
+++ b/gin/panels.go
@@ -2,10 +2,13 @@ package gin
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gmc-norr/cleve"
 	"github.com/gmc-norr/cleve/mongo"
 )
 
@@ -55,5 +58,37 @@ func PanelHandler(db *mongo.DB) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, panel)
+	}
+}
+
+func AddPanelHandler(db *mongo.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.ContentType() != "application/json" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unsupported content type: %s", c.ContentType())})
+			return
+		}
+
+		var p cleve.GenePanel
+		if err := c.ShouldBindJSON(&p); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error(), "when": "parsing panel"})
+			return
+		}
+		if p.Date.IsZero() {
+			p.Date = cleve.Time{Time: time.Now()}
+		}
+		slog.Info("adding panel", "panel", p)
+		if err := p.Validate(); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := db.CreatePanel(p); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "a panel with this id and version already exists"})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"message": "successfully created the panel", "id": p.Id, "name": p.Name, "version": p.Version})
 	}
 }

--- a/gin/panels.go
+++ b/gin/panels.go
@@ -100,9 +100,14 @@ func AddPanelHandler(db *mongo.DB) gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+
 		if err := db.CreatePanel(p.GenePanel); err != nil {
 			if mongo.IsDuplicateKeyError(err) {
 				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "a panel with this id and version already exists"})
+				return
+			}
+			if errors.Is(err, mongo.ConflictError) {
+				c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": err.Error(), "id": p.Id})
 				return
 			}
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/gin/router.go
+++ b/gin/router.go
@@ -208,6 +208,7 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 	authEndpoints := r.Group("/")
 	authEndpoints.Use(authMiddleware(db))
 	authEndpoints.POST("/api/panels", AddPanelHandler(db))
+	authEndpoints.PATCH("/api/panels/:panelId/archive", ArchivePanelHandler(db))
 	authEndpoints.POST("/api/runs", AddRunHandler(db))
 	authEndpoints.POST("/api/runs/:runId/analysis", AddAnalysisHandler(db))
 	authEndpoints.PATCH("/api/runs/:runId/analysis/:analysisId", UpdateAnalysisHandler(db))

--- a/gin/router.go
+++ b/gin/router.go
@@ -207,6 +207,7 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 
 	authEndpoints := r.Group("/")
 	authEndpoints.Use(authMiddleware(db))
+	authEndpoints.POST("/api/panels", AddPanelHandler(db))
 	authEndpoints.POST("/api/runs", AddRunHandler(db))
 	authEndpoints.POST("/api/runs/:runId/analysis", AddAnalysisHandler(db))
 	authEndpoints.PATCH("/api/runs/:runId/analysis/:analysisId", UpdateAnalysisHandler(db))

--- a/gin/router.go
+++ b/gin/router.go
@@ -174,6 +174,8 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 	r.GET("/", DashboardHandler(db))
 	r.GET("/runs", DashboardHandler(db))
 	r.GET("/runs/:runId", DashboardRunHandler(db))
+	r.GET("/panels", DashboardPanelHandler(db))
+	r.GET("/panels/:panelId", DashboardPanelHandler(db))
 	r.GET("/qc", DashboardQCHandler(db))
 	r.GET("/qc/charts/global", GlobalChartsHandler(db))
 	r.GET("/qc/charts/run/:runId", RunChartsHandler(db))
@@ -181,6 +183,7 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 	hxEndpoints := r.Group("/")
 	hxEndpoints.Use(hxMiddleware())
 	hxEndpoints.GET("/runtable", DashboardRunTable(db))
+	hxEndpoints.GET("/panel-list", DashboardPanelListHandler(db))
 
 	// API endpoints
 	r.GET("/api", func(c *gin.Context) {

--- a/gin/router.go
+++ b/gin/router.go
@@ -196,6 +196,8 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 	r.GET("/api/runs/:runId/analysis/:analysisId", AnalysisHandler(db))
 	r.GET("/api/runs/:runId/samplesheet", RunSampleSheetHandler(db))
 	r.GET("/api/runs/:runId/qc", RunQcHandler(db))
+	r.GET("/api/panels", PanelsHandler(db))
+	r.GET("/api/panels/:panelId", PanelHandler(db))
 	r.GET("/api/platforms", PlatformsHandler(db))
 	r.GET("/api/platforms/:platformName", GetPlatformHandler(db))
 	r.GET("/api/qc/:platformName", AllRunQcHandler(db))

--- a/mongo/db.go
+++ b/mongo/db.go
@@ -68,6 +68,10 @@ func (db DB) KeyCollection() *mongo.Collection {
 	return db.Collection("keys")
 }
 
+func (db DB) PanelCollection() *mongo.Collection {
+	return db.Collection("panels")
+}
+
 func (db DB) RunQCCollection() *mongo.Collection {
 	return db.Collection("run_qc")
 }
@@ -98,6 +102,12 @@ func (db *DB) SetIndexes() error {
 		return fmt.Errorf("failed to set index on samplesheets, does the collection exist? %w", err)
 	}
 	log.Printf("Set index %s on samplesheets", name)
+
+	name, err = db.SetPanelIndex()
+	if err != nil {
+		return fmt.Errorf("failed to set index on panels, does the collection exist? %w", err)
+	}
+	log.Printf("Set index %s on panels", name)
 
 	return nil
 }
@@ -136,6 +146,12 @@ func (db *DB) Init(ctx context.Context) error {
 	if err := createCollection("samples"); err != nil {
 		return err
 	}
+	if err := createCollection("panels"); err != nil {
+		return err
+	}
+	if _, err := db.SetPanelIndex(); err != nil {
+		return err
+	}
 	if err := createCollection("samplesheets"); err != nil {
 		return err
 	}
@@ -161,10 +177,16 @@ func (db *DB) GetIndexes() (map[string][]map[string]string, error) {
 		return nil, err
 	}
 
+	panelIndex, err := db.PanelIndex()
+	if err != nil {
+		return nil, err
+	}
+
 	indexes := make(map[string][]map[string]string)
 	indexes["runs"] = runIndex
 	indexes["run_qc"] = runQcIndex
 	indexes["samplesheets"] = sampleSheetIndex
+	indexes["panels"] = panelIndex
 
 	return indexes, nil
 }

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -1,6 +1,11 @@
 package mongo
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var ConflictError = errors.New("conflicting operation")
 
 type PageOutOfBoundsError struct {
 	page       int

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -1,0 +1,273 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gmc-norr/cleve"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Panels returns all gene panels in the collection, but without the
+// genes that they contain. Only the most recent panel for each ID
+// is returned, based on creation date. Control what panels are returned
+// with the filter that is passed in.
+func (db DB) Panels(filter cleve.PanelFilter) ([]cleve.GenePanel, error) {
+	var pipeline mongo.Pipeline
+	var panels []cleve.GenePanel
+
+	matchFields := bson.D{
+		{Key: "archived", Value: filter.Archived},
+	}
+	if filter.Category != "" {
+		matchFields = append(matchFields, bson.E{
+			Key: "categories", Value: bson.D{
+				{Key: "$elemMatch", Value: bson.D{{Key: "$eq", Value: filter.Category}}},
+			},
+		})
+	}
+	if filter.GeneQuery != "" {
+		matchFields = append(matchFields, bson.E{
+			Key: "genes", Value: bson.D{
+				{Key: "$elemMatch", Value: bson.D{
+					{Key: "symbol", Value: bson.D{
+						{Key: "$regex", Value: filter.GeneQuery},
+						{Key: "$options", Value: "i"},
+					}},
+				}},
+			},
+		})
+	}
+	if filter.Gene != "" {
+		matchFields = append(matchFields, bson.E{
+			Key: "genes", Value: bson.D{
+				{Key: "$elemMatch", Value: bson.D{
+					{Key: "symbol", Value: bson.D{
+						{Key: "$regex", Value: "^" + filter.Gene + "$"},
+						{Key: "$options", Value: "i"},
+					}},
+				}},
+			},
+		})
+	}
+	if filter.NameQuery != "" {
+		matchFields = append(matchFields, bson.E{
+			Key: "name", Value: bson.D{
+				{Key: "$regex", Value: filter.NameQuery},
+				{Key: "$options", Value: "i"},
+			},
+		})
+	}
+
+	pipeline = mongo.Pipeline([]bson.D{
+		{{Key: "$match", Value: matchFields}},
+		{{Key: "$project", Value: bson.D{
+			{Key: "genes", Value: 0},
+		}}},
+		{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: "$id"},
+			{Key: "panel", Value: bson.D{
+				{Key: "$top", Value: bson.D{
+					{Key: "output", Value: "$$ROOT"},
+					{Key: "sortBy", Value: bson.D{
+						{Key: "date", Value: -1},
+					}},
+				}},
+			}},
+		}}},
+		{{Key: "$unwind", Value: bson.D{
+			{Key: "path", Value: "$panel"},
+		}}},
+
+		{{Key: "$replaceRoot", Value: bson.D{
+			{Key: "newRoot", Value: "$panel"},
+		}}},
+
+		{{Key: "$sort", Value: bson.D{
+			{Key: "name", Value: 1},
+		}}},
+	})
+
+	cursor, err := db.PanelCollection().Aggregate(context.TODO(), pipeline)
+	if err != nil {
+		return panels, err
+	}
+
+	for cursor.Next(context.TODO()) {
+		p := cleve.GenePanel{}
+		if err := cursor.Decode(&p); err != nil {
+			return panels, err
+		}
+		panels = append(panels, p)
+	}
+
+	return panels, nil
+}
+
+// Panel returns a specific gene panel given an ID and a version. If the panel
+// does not exist, an error is returned.
+func (db DB) Panel(id string, version string) (cleve.GenePanel, error) {
+	var p cleve.GenePanel
+	err := db.PanelCollection().FindOne(context.TODO(), bson.D{{Key: "id", Value: id}, {Key: "version", Value: version}}).Decode(&p)
+	return p, err
+}
+
+// PanelVersions returns a slice of panel versions that exist for a given panel ID.
+// The versions are sorted in reverse chronological order based on creation date.
+func (db DB) PanelVersions(id string) ([]cleve.GenePanelVersion, error) {
+	var versions []cleve.GenePanelVersion
+
+	pipeline := mongo.Pipeline([]bson.D{
+		{{Key: "$match", Value: bson.D{
+			{Key: "id", Value: id},
+		}}},
+		{{Key: "$project", Value: bson.D{
+			{Key: "version", Value: 1},
+			{Key: "date", Value: 1},
+		}}},
+		{{Key: "$sort", Value: bson.D{
+			{Key: "date", Value: -1},
+		}}},
+	})
+
+	cursor, err := db.PanelCollection().Aggregate(context.TODO(), pipeline)
+	if err != nil {
+		return versions, err
+	}
+
+	for cursor.Next(context.TODO()) {
+		var v cleve.GenePanelVersion
+		if err := cursor.Decode(&v); err != nil {
+			return versions, err
+		}
+		versions = append(versions, v)
+	}
+
+	return versions, nil
+}
+
+// PanelCategories returns a slice of strings representing all panel categories in the
+// database. Only unique entries are returned, and they are sorted lexicographically.
+func (db DB) PanelCategories() ([]string, error) {
+	categories := make([]string, 0)
+	pipeline := mongo.Pipeline([]bson.D{
+		{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: "$id"},
+			{Key: "panel", Value: bson.D{
+				{Key: "$top", Value: bson.D{
+					{Key: "output", Value: "$$ROOT"},
+					{Key: "sortBy", Value: bson.D{{Key: "date", Value: -1}}},
+				}},
+			}},
+		}}},
+		{{Key: "$replaceRoot", Value: bson.D{{Key: "newRoot", Value: "$panel"}}}},
+		{{Key: "$project", Value: bson.D{{Key: "category", Value: "$categories"}}}},
+		{{Key: "$unwind", Value: bson.D{
+			{Key: "path", Value: "$category"},
+			{Key: "preserveNullAndEmptyArrays", Value: false},
+		}}},
+		{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: nil},
+			{Key: "categories", Value: bson.D{
+				{Key: "$addToSet", Value: "$category"},
+			}},
+		}}},
+		{{Key: "$addFields", Value: bson.D{
+			{Key: "categories", Value: bson.D{
+				{Key: "$sortArray", Value: bson.D{
+					{Key: "input", Value: "$categories"},
+					{Key: "sortBy", Value: 1},
+				}},
+			}},
+		}}},
+	})
+	cursor, err := db.PanelCollection().Aggregate(context.TODO(), pipeline)
+	if err != nil {
+		return categories, err
+	}
+	defer cursor.Close(context.TODO())
+	cursor.Next(context.TODO())
+
+	type aux struct {
+		Categories []string
+	}
+	var c aux
+	if err := cursor.Decode(&c); err != nil {
+		return categories, err
+	}
+
+	return c.Categories, nil
+}
+
+// CreatePanel takes adds a new gene panel to the database. If a panel with the
+// same ID and version already exists, an error is returned.
+func (db DB) CreatePanel(p cleve.GenePanel) error {
+	auxPanel := struct {
+		ImportedAt      time.Time
+		cleve.GenePanel `bson:",inline"`
+	}{
+		ImportedAt: time.Now().UTC(),
+		GenePanel:  p,
+	}
+	_, err := db.PanelCollection().InsertOne(context.TODO(), auxPanel)
+	return err
+}
+
+// ArchivePanel archives a panel given an ID. All existing versions of the panel are
+// archived.
+func (db DB) ArchivePanel(id string) error {
+	_, err := db.PanelCollection().UpdateMany(context.TODO(), bson.D{{Key: "id", Value: id}}, bson.D{{Key: "$set", Value: bson.D{{Key: "archived", Value: true}}}})
+	return err
+}
+
+// PanelIndex returns the the current indexes for the panel collection.
+func (db DB) PanelIndex() ([]map[string]string, error) {
+	cursor, err := db.RunCollection().Indexes().List(context.TODO())
+	if err != nil {
+		return []map[string]string{}, err
+	}
+	defer cursor.Close(context.TODO())
+
+	var indexes []map[string]string
+
+	var result []bson.M
+	if err = cursor.All(context.TODO(), &result); err != nil {
+		return []map[string]string{}, err
+	}
+
+	for _, v := range result {
+		i := map[string]string{}
+		for k, val := range v {
+			i[k] = fmt.Sprintf("%v", val)
+		}
+		indexes = append(indexes, i)
+	}
+
+	return indexes, nil
+}
+
+// SetPanelIndex sets all indexes for the panel collection. Existing indexes
+// are removed before new indexes are created.
+func (db *DB) SetPanelIndex() (string, error) {
+	indexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "id", Value: 1},
+			{Key: "version", Value: 1},
+		},
+		Options: options.Index().SetUnique(true),
+	}
+
+	// TODO: do this as a transaction and roll back if anything fails
+	_, err := db.PanelCollection().Indexes().DropAll(context.TODO())
+	if err != nil {
+		return "", err
+	}
+
+	// log.Printf("Dropped %d indexes\n", res.Lookup("nIndexesWas").Int32())
+
+	name, err := db.PanelCollection().Indexes().CreateOne(context.TODO(), indexModel)
+	return name, err
+}

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -2,7 +2,9 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/gmc-norr/cleve"
@@ -234,11 +236,12 @@ func (db DB) PanelCategories() ([]string, error) {
 		Categories []string
 	}
 	var c aux
-	if err := cursor.Decode(&c); err != nil {
-		return categories, err
-	}
+	err = cursor.Decode(&c)
 
-	return c.Categories, nil
+	if errors.Is(err, io.EOF) {
+		return c.Categories, nil
+	}
+	return c.Categories, err
 }
 
 // CreatePanel takes adds a new gene panel to the database. If a panel with the

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -146,6 +146,10 @@ func (db DB) PanelVersions(id string) ([]cleve.GenePanelVersion, error) {
 		versions = append(versions, v)
 	}
 
+	if len(versions) == 0 {
+		return versions, ErrNoDocuments
+	}
+
 	return versions, nil
 }
 

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -303,6 +303,30 @@ func (db DB) UnarchivePanel(id string) error {
 	return nil
 }
 
+// DeletePanel deletes either a single version of a panel if both `name` and `version` are,
+// given. If `version` is the empty string, then all versions of a panel ID are deleted.
+// Returns the number of documents deleted and an error.
+func (db DB) DeletePanel(id string, version string) (int, error) {
+	var err error
+	var res *mongo.DeleteResult
+	deleteAll := version == ""
+	if deleteAll {
+		res, err = db.PanelCollection().DeleteMany(
+			context.TODO(),
+			bson.D{{Key: "id", Value: id}},
+		)
+	} else {
+		res, err = db.PanelCollection().DeleteOne(
+			context.TODO(),
+			bson.D{
+				{Key: "id", Value: id},
+				{Key: "version", Value: version},
+			},
+		)
+	}
+	return int(res.DeletedCount), err
+}
+
 // PanelIndex returns the the current indexes for the panel collection.
 func (db DB) PanelIndex() ([]map[string]string, error) {
 	cursor, err := db.RunCollection().Indexes().List(context.TODO())

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -16,11 +16,17 @@ import (
 // is returned, based on creation date. Control what panels are returned
 // with the filter that is passed in.
 func (db DB) Panels(filter cleve.PanelFilter) ([]cleve.GenePanel, error) {
-	var pipeline mongo.Pipeline
-	var panels []cleve.GenePanel
+	var (
+		pipeline mongo.Pipeline
+		panels   []cleve.GenePanel
+	)
 
-	matchFields := bson.D{
-		{Key: "archived", Value: filter.Archived},
+	matchFields := bson.D{}
+
+	if !filter.Archived {
+		matchFields = append(matchFields, bson.E{
+			Key: "archived", Value: false,
+		})
 	}
 	if filter.Category != "" {
 		matchFields = append(matchFields, bson.E{

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -274,8 +274,11 @@ func (db DB) CreatePanel(p cleve.GenePanel) error {
 	if existingPanel.Archived {
 		return fmt.Errorf("%w: panel is archived", ConflictError)
 	}
+	if existingPanel.Version.NewerThan(p.Version) {
+		return fmt.Errorf("%w: a newer version of this panel already exists, most recent version is %s", ConflictError, existingPanel.Version)
+	}
 	if existingPanel.Date.After(p.Date) {
-		return fmt.Errorf("%w: a newer version of this panel already exists", ConflictError)
+		return fmt.Errorf("%w: a version with a more recent creation date already exists", ConflictError)
 	}
 	if time.Now().Before(p.Date) {
 		return fmt.Errorf("%w: panel cannot have a creation date in the future", ConflictError)

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -219,8 +219,27 @@ func (db DB) CreatePanel(p cleve.GenePanel) error {
 // ArchivePanel archives a panel given an ID. All existing versions of the panel are
 // archived.
 func (db DB) ArchivePanel(id string) error {
-	_, err := db.PanelCollection().UpdateMany(context.TODO(), bson.D{{Key: "id", Value: id}}, bson.D{{Key: "$set", Value: bson.D{{Key: "archived", Value: true}}}})
-	return err
+	res, err := db.PanelCollection().UpdateMany(context.TODO(), bson.D{{Key: "id", Value: id}}, bson.D{{Key: "$set", Value: bson.D{{Key: "archived", Value: true}}}})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNoDocuments
+	}
+	return nil
+}
+
+// UnarchivePanel unarchives a panel given an ID. All existing versions of the panel are
+// unarchived.
+func (db DB) UnarchivePanel(id string) error {
+	res, err := db.PanelCollection().UpdateMany(context.TODO(), bson.D{{Key: "id", Value: id}}, bson.D{{Key: "$set", Value: bson.D{{Key: "archived", Value: false}}}})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNoDocuments
+	}
+	return nil
 }
 
 // PanelIndex returns the the current indexes for the panel collection.

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -229,7 +229,16 @@ func (db DB) CreatePanel(p cleve.GenePanel) error {
 // ArchivePanel archives a panel given an ID. All existing versions of the panel are
 // archived.
 func (db DB) ArchivePanel(id string) error {
-	res, err := db.PanelCollection().UpdateMany(context.TODO(), bson.D{{Key: "id", Value: id}}, bson.D{{Key: "$set", Value: bson.D{{Key: "archived", Value: true}}}})
+	res, err := db.PanelCollection().UpdateMany(
+		context.TODO(),
+		bson.D{{Key: "id", Value: id}},
+		[]bson.D{
+			{{Key: "$addFields", Value: bson.D{
+				{Key: "archived", Value: true},
+				{Key: "archivedat", Value: time.Now()},
+			}}},
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -242,7 +251,17 @@ func (db DB) ArchivePanel(id string) error {
 // UnarchivePanel unarchives a panel given an ID. All existing versions of the panel are
 // unarchived.
 func (db DB) UnarchivePanel(id string) error {
-	res, err := db.PanelCollection().UpdateMany(context.TODO(), bson.D{{Key: "id", Value: id}}, bson.D{{Key: "$set", Value: bson.D{{Key: "archived", Value: false}}}})
+	res, err := db.PanelCollection().UpdateMany(
+		context.TODO(),
+		bson.D{{Key: "id", Value: id}},
+		[]bson.D{
+			{{Key: "$addFields", Value: bson.D{
+				{Key: "archived", Value: false},
+			}}},
+			{{Key: "$project", Value: bson.D{
+				{Key: "archivedat", Value: 0},
+			}}},
+		})
 	if err != nil {
 		return err
 	}

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -21,6 +21,7 @@ func (db DB) Panels(filter cleve.PanelFilter) ([]cleve.GenePanel, error) {
 		panels   []cleve.GenePanel
 	)
 
+	panels = make([]cleve.GenePanel, 0)
 	matchFields := bson.D{}
 
 	if !filter.Archived {

--- a/panel.go
+++ b/panel.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -32,7 +33,7 @@ type GenePanelVersion struct {
 }
 
 type Gene struct {
-	HGNC    string
+	HGNC    int
 	Symbol  string
 	Aliases []string
 }
@@ -160,13 +161,17 @@ func genePanelFromText(r io.Reader, delim rune) (GenePanel, error) {
 			for i, val := range rec {
 				switch header[i] {
 				case "hgnc", "hgnc_id":
-					g.HGNC = val
+					hgnc, err := strconv.Atoi(val)
+					if err != nil {
+						return p, fmt.Errorf("failed to parse HGNC ID: %w", err)
+					}
+					g.HGNC = hgnc
 				case "hgnc_symbol", "symbol":
 					g.Symbol = val
 				}
 			}
 
-			if g.HGNC == "" {
+			if g.HGNC == 0 {
 				return p, fmt.Errorf("missing HGNC ID for record on line %d", line+1)
 			}
 

--- a/panel.go
+++ b/panel.go
@@ -13,18 +13,18 @@ import (
 
 type GenePanel struct {
 	GenePanelVersion `bson:",inline"`
-	Id               string
-	Name             string
-	Description      string
-	Categories       []string
-	Genes            []Gene
-	Archived         bool
-	ArchivedAt       time.Time `bson:",omitzero"`
+	Id               string    `json:"id"`
+	Name             string    `json:"name"`
+	Description      string    `json:"description"`
+	Categories       []string  `json:"categories"`
+	Genes            []Gene    `json:"genes,omitzero"`
+	Archived         bool      `json:"archived"`
+	ArchivedAt       time.Time `bson:",omitzero" json:"archived_at,omitzero"`
 }
 
 type GenePanelVersion struct {
-	Version string
-	Date    time.Time
+	Version string    `json:"version"`
+	Date    time.Time `json:"date"`
 }
 
 type Gene struct {

--- a/panel.go
+++ b/panel.go
@@ -12,14 +12,18 @@ import (
 )
 
 type GenePanel struct {
-	Id          string
-	Name        string
-	Version     string
-	Date        time.Time
-	Description string
-	Categories  []string
-	Genes       []Gene
-	Archived    bool
+	GenePanelVersion `bson:",inline"`
+	Id               string
+	Name             string
+	Description      string
+	Categories       []string
+	Genes            []Gene
+	Archived         bool
+}
+
+type GenePanelVersion struct {
+	Version string
+	Date    time.Time
 }
 
 type Gene struct {
@@ -30,10 +34,13 @@ type Gene struct {
 
 func NewGenePanel(name string, description string) GenePanel {
 	return GenePanel{
+		GenePanelVersion: GenePanelVersion{
+			Version: "1.0",
+			Date:    time.Now(),
+		},
 		Id:          name,
 		Name:        name,
 		Description: description,
-		Version:     "1.0",
 		Genes:       make([]Gene, 0),
 	}
 }

--- a/panel.go
+++ b/panel.go
@@ -84,6 +84,22 @@ func (p *GenePanel) AddCategory(category string) {
 	}
 }
 
+func (p GenePanel) Validate() error {
+	if p.Id == "" {
+		return errors.New("panel must have an id")
+	}
+	if p.Name == "" {
+		return errors.New("panel must have a name")
+	}
+	if p.Version == "" {
+		return errors.New("panel must have a version")
+	}
+	if len(p.Genes) == 0 {
+		return errors.New("panel must contain at least one gene")
+	}
+	return nil
+}
+
 func parseKeyValue(s string) (string, string, error) {
 	elems := strings.SplitN(s, "=", 2)
 	if len(elems) != 2 {

--- a/panel.go
+++ b/panel.go
@@ -73,6 +73,11 @@ func (p GenePanel) Validate() error {
 	if len(p.Genes) == 0 {
 		return errors.New("panel must contain at least one gene")
 	}
+	for _, g := range p.Genes {
+		if g.HGNC == 0 {
+			return errors.New("missing HGNC ID for at least one gene")
+		}
+	}
 	return nil
 }
 

--- a/panel.go
+++ b/panel.go
@@ -19,6 +19,7 @@ type GenePanel struct {
 	Categories       []string
 	Genes            []Gene
 	Archived         bool
+	ArchivedAt       time.Time `bson:",omitzero"`
 }
 
 type GenePanelVersion struct {
@@ -33,15 +34,17 @@ type Gene struct {
 }
 
 func NewGenePanel(name string, description string) GenePanel {
+	n := time.Now()
 	return GenePanel{
 		GenePanelVersion: GenePanelVersion{
 			Version: "1.0",
-			Date:    time.Now(),
+			Date:    n,
 		},
 		Id:          name,
 		Name:        name,
 		Description: description,
 		Genes:       make([]Gene, 0),
+		ArchivedAt:  n,
 	}
 }
 

--- a/panel.go
+++ b/panel.go
@@ -1,0 +1,138 @@
+package cleve
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+type GenePanel struct {
+	Id          string
+	Name        string
+	Version     string
+	Description string
+	Genes       []Gene
+}
+
+type Gene struct {
+	HGNC    string
+	Symbol  string
+	Aliases []string
+}
+
+func NewGenePanel(name string, description string) GenePanel {
+	return GenePanel{
+		Id:          name,
+		Name:        name,
+		Description: description,
+		Version:     "1.0",
+		Genes:       make([]Gene, 0),
+	}
+}
+
+func parseKeyValue(s string) (string, string, error) {
+	elems := strings.SplitN(s, "=", 2)
+	if len(elems) != 2 {
+		return "", "", errors.New("invalid metadata line")
+	}
+	key, _ := strings.CutPrefix(elems[0], "##")
+	value := elems[1]
+	return key, value, nil
+}
+
+func genePanelFromText(r io.Reader, delim rune) (GenePanel, error) {
+	var p GenePanel
+
+	csvReader := csv.NewReader(r)
+	csvReader.Comma = delim
+	csvReader.FieldsPerRecord = -1
+
+	var (
+		parsedHeader bool
+		header       []string
+		nRecords     int
+	)
+
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return p, err
+	}
+
+	for line, rec := range records {
+		if strings.HasPrefix(rec[0], "##") {
+			key, value, err := parseKeyValue(strings.Join(rec, fmt.Sprintf("%c", delim)))
+			if err != nil {
+				return p, err
+			}
+			switch key {
+			case "display_name", "name":
+				p.Name = value
+			case "panel_id", "id":
+				p.Id = value
+			case "version":
+				p.Version = value
+			case "description":
+				p.Description = value
+			default:
+				slog.Warn("unknown metadata field", "key", key)
+			}
+		} else if strings.HasPrefix(rec[0], "#") {
+			if parsedHeader {
+				return p, errors.New("multiple header lines found")
+			}
+			header = rec
+			header[0], _ = strings.CutPrefix(header[0], "#")
+			parsedHeader = true
+		} else {
+			if !parsedHeader {
+				header = []string{"hgnc_id", "hgnc_symbol", "disease_associated_transcripts", "mosaicism", "reduced_penetrance"}
+				parsedHeader = true
+			}
+
+			if nRecords == 0 {
+				nRecords = len(rec)
+			} else if len(rec) != nRecords {
+				return p, fmt.Errorf("record on line %d: wrong number of fields", line+1)
+			}
+
+			g := Gene{}
+
+			for i, val := range rec {
+				switch header[i] {
+				case "hgnc", "hgnc_id":
+					g.HGNC = val
+				case "hgnc_symbol", "symbol":
+					g.Symbol = val
+				}
+			}
+
+			if g.HGNC == "" {
+				return p, fmt.Errorf("missing HGNC ID for record on line %d", line+1)
+			}
+
+			p.Genes = append(p.Genes, g)
+		}
+	}
+
+	return p, err
+}
+
+func GenePanelFromCsv(r io.Reader) (GenePanel, error) {
+	return genePanelFromText(r, ';')
+}
+
+func GenePanelFromTsv(r io.Reader) (GenePanel, error) {
+	return genePanelFromText(r, '\t')
+}
+
+func GenePanelFromYaml(r io.Reader) (GenePanel, error) {
+	var p GenePanel
+	return p, nil
+}
+
+func (p *GenePanel) Add(gene Gene) {
+	p.Genes = append(p.Genes, gene)
+}

--- a/panel.go
+++ b/panel.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -16,44 +15,20 @@ type Time struct {
 	time.Time
 }
 
-func (t *Time) UnmarshalJSON(data []byte) error {
-	layouts := []string{
-		time.RFC3339,
-		"2006-01-02T15:04:05MST",
-		"2006-01-02 15:04:05 MST",
-		"2006-01-02T15:04:05",
-		"2006-01-02 15:04:05",
-		"20060102",
-		"060102",
-	}
-	for _, l := range layouts {
-		rawTime, err := strconv.Unquote(string(data))
-		if err != nil {
-			return err
-		}
-		d, err := time.Parse(l, rawTime)
-		if err == nil {
-			*t = Time{d}
-			return nil
-		}
-	}
-	return fmt.Errorf("failed to parse time %s", string(data))
-}
-
 type GenePanel struct {
 	GenePanelVersion `bson:",inline" json:",inline"`
-	Id               string   `json:"id"`
-	Name             string   `json:"name"`
-	Description      string   `json:"description"`
-	Categories       []string `json:"categories"`
-	Genes            []Gene   `json:"genes,omitzero"`
-	Archived         bool     `json:"archived"`
-	ArchivedAt       Time     `bson:",omitzero" json:"archived_at,omitzero"`
+	Id               string    `json:"id"`
+	Name             string    `json:"name"`
+	Description      string    `json:"description"`
+	Categories       []string  `json:"categories"`
+	Genes            []Gene    `json:"genes,omitzero"`
+	Archived         bool      `json:"archived"`
+	ArchivedAt       time.Time `bson:",omitzero" json:"archived_at,omitzero"`
 }
 
 type GenePanelVersion struct {
-	Version string `json:"version"`
-	Date    Time   `json:"date"`
+	Version string    `json:"version"`
+	Date    time.Time `json:"date"`
 }
 
 type Gene struct {
@@ -63,7 +38,7 @@ type Gene struct {
 }
 
 func NewGenePanel(name string, description string) GenePanel {
-	n := Time{time.Now()}
+	n := time.Now()
 	return GenePanel{
 		GenePanelVersion: GenePanelVersion{
 			Version: "1.0",
@@ -142,11 +117,10 @@ func genePanelFromText(r io.Reader, delim rune) (GenePanel, error) {
 			case "version":
 				p.Version = value
 			case "date":
-				t, err := time.Parse("2006-01-02", value)
+				p.Date, err = time.Parse("2006-01-02", value)
 				if err != nil {
 					return p, fmt.Errorf("error parsing date on line %d: %w", line, err)
 				}
-				p.Date = Time{t}
 			case "description":
 				p.Description = value
 			case "categories":

--- a/templates/error404.tmpl
+++ b/templates/error404.tmpl
@@ -1,5 +1,5 @@
 {{ define "error404" }}
-{{ template "header" }}
+{{ template "header" . }}
 <section class="mx-6">
     <h1 class="text-4xl mb-4">404 Page not found</h1>
     <p class="error my-4">

--- a/templates/error500.tmpl
+++ b/templates/error500.tmpl
@@ -1,7 +1,12 @@
 {{ define "error500" }}
 {{ template "header" . }}
-<h1>Internal server error</h1>
-<p>Something went wrong on our side. We're looking into it.</p>
-<p><pre>{{ .error }}</pre></p>
+<section class="mx-6">
+    <h1 class="text-4xl mb-4">500 Internal Server Error</h1>
+    <p class="error my-4">
+        {{ if .error }}
+        Error: {{ .error }}
+        {{ end }}
+    </p>
+</section>
 {{ template "footer" }}
 {{ end }}

--- a/templates/error500.tmpl
+++ b/templates/error500.tmpl
@@ -1,5 +1,5 @@
 {{ define "error500" }}
-{{ template "header" }}
+{{ template "header" . }}
 <h1>Internal server error</h1>
 <p>Something went wrong on our side. We're looking into it.</p>
 <p><pre>{{ .error }}</pre></p>

--- a/templates/header.tmpl
+++ b/templates/header.tmpl
@@ -13,11 +13,12 @@
             <ul class="list-none">
                 <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/runs">Runs</a></li>
                 <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/qc">QC</a></li>
+                <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/panels">Gene panels</a></li>
             </ul>
         </nav>
-        {{ if .version }}
+        {{ if .cleve_version }}
         <div class="absolute top-0 right-0 text-sm mt-1 mr-2">
-            <p>cleve {{ .version }}</p>
+            <p>cleve {{ .cleve_version }}</p>
         </div>
         {{ end }}
     </header>

--- a/templates/panels.tmpl
+++ b/templates/panels.tmpl
@@ -1,0 +1,119 @@
+{{ define "panel-list" }}
+{{ $filter := .filter }}
+<aside class="min-w-3xs">
+    <form
+        class="grid grid-cols-1 mb-2"
+        hx-get="/panel-list"
+        hx-select="#panel-list"
+        hx-target="#panel-list"
+        hx-indicator="#spinner"
+        hx-trigger="search, change from:select[name=category], keyup changed delay:300ms from:input[type=search]">
+        <label for="category" class="block text-sm/6 font-medium text-gray-900" title="Only show panels belonging to a specific category.">
+            Category
+        </label>
+        <select name="category" id="category" class="border-1 rounded-md border-gray-500">
+            <option value=""{{ if eq "" $filter.Category }} selected{{ end }}>All</option>
+            {{ range .categories }}
+            <option value="{{ . }}"{{ if eq . $filter.Category }} selected{{ end }}>{{ . }}</option>
+            {{ end }}
+        </select>
+        <label for="name-query" class="block text-sm/6 font-medium text-gray-900" title="Search for a panel with a specific name.">
+            Name
+        </label>
+        <input id="name-query" class="border-1 rounded-md border-gray-500 px-1" name="name-query" type="search" placeholder="Panel name" value="{{ .filter.Name }}" />
+        <label for="gene" class="block text-sm/6 font-medium text-gray-900" title="Search for a panel containing a particular gene. Only exact matches will be returned (case insentitive).">
+            Gene
+        </label>
+        <input id="gene" class="border-1 rounded-md border-gray-500 px-1" name="gene" type="search" placeholder="Gene symbol" value="{{ .filter.Gene }}" />
+    </form>
+    <div id="panel-list" class="my-2">
+        {{ $nPanels := .panels | len }}
+        <p class="text-xs my-2">
+        {{ if not .panels }}
+            No gene panels available
+        {{ else }}
+            Showing {{ $nPanels }} panel{{ if ne $nPanels 1 }}s{{ end }}
+        {{ end }}
+        </p>
+        <ul id="panel-list">
+            {{ range .panels }}
+            <li>
+                <a
+                    class="cursor-pointer text-accent-900"
+                    title="{{ .Name }} v{{ .Version }}"
+                    href="/panels/{{ .Id }}"
+                    hx-get="/panels/{{ .Id }}"
+                    hx-indicator="#spinner"
+                    hx-target="#panel-info">
+                    {{ .Name }}
+                </a>
+            </li>
+            {{ end }}
+    </div>
+</aside>
+{{ end }}
+
+{{ define "panels" }}
+{{ template "header" . }}
+<h2 class="text-3xl mx-6 my-4">Gene panels <img id="spinner" class="inline-block size-[.8em] htmx-indicator animate-spin" src="/static/img/spinner.svg"></h2>
+
+<div class="flex mx-6 gap-12">
+    {{ template "panel-list" . }}
+
+    <section id="panel-info" class="max-w-4xl">
+        {{ if .panel }}
+        {{ template "panel-info" . }}
+        {{ else }}
+        <p>Here all available gene panels are presented. Select a panel on the left to show more details.</p>
+        {{ end }}
+    </section>
+</div>
+{{ template "footer" . }}
+{{ end }}
+
+{{ define "panel-info" }}
+{{ $panelId := .panel.Id }}
+{{ $panelVersion := .panel.Version }}
+<header>
+    <h3 class="text-2xl">{{ .panel.Name }} ({{ .panel.Genes | len }} genes)</h3>
+    <select class="my-2"
+            name="version"
+            hx-get="/panels/{{ $panelId }}"
+            hx-target="#panel-info"
+            hx-indicator="#spinner">
+        {{ range .versions }}
+        <option
+            value="{{ .Version }}"
+            {{ if eq .Version $panelVersion }} selected{{ end }}>
+            v{{ .Version }} ({{ .Date.Format "2006-01-02" }})
+        </option>
+        {{ end }}
+    </select>
+    <div class="my-2 flex flex-wrap gap-2 text-sm text-slate-600">
+        {{ range .panel.Categories }}<span class="flex-none px-3 py-1 bg-slate-200 rounded-full">{{ . | printf "%s" }}</span>{{ end }}
+    </div>
+</header>
+
+<p class="my-4">{{ .panel.Description }}</p>
+
+<table class="table-auto my-4 min-w-2xs">
+    <thead class="bg-accent-900 text-accent-100">
+        <tr>
+            <th class="px-2 text-left">Symbol</th>
+            <th class="px-2 text-right">HGNC ID</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ range .panel.Genes }}
+        <tr class="hover:bg-accent-100 border-b border-gray-200">
+            <td class="px-2 text-left">{{ .Symbol }}</td>
+            <td class="px-2 text-right"><a class="text-accent-900" href="https://genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:{{ .HGNC }}">{{ .HGNC }}</a></td>
+        </tr>
+        {{ end }}
+    </tbody>
+<table>
+
+<p class="my-4 text-xs">
+    {{ .panel.Name }} v{{ .panel.Version }} created on {{ .panel.Date.Format "2006-01-02" }}
+</p>
+{{ end }}

--- a/templates/panels.tmpl
+++ b/templates/panels.tmpl
@@ -75,7 +75,10 @@
 {{ $panelId := .panel.Id }}
 {{ $panelVersion := .panel.Version }}
 <header>
-    <h3 class="text-2xl">{{ .panel.Name }} ({{ .panel.Genes | len }} genes)</h3>
+    <h3 class="text-2xl">
+        {{ .panel.Name }} ({{ .panel.Genes | len }} genes)
+        {{ if .panel.Archived }}<span class="inline-block py-1 px-2 rounded-md bg-red-600 text-white">Archived</span>{{ end }}
+    </h3>
     <select class="my-2"
             name="version"
             hx-get="/panels/{{ $panelId }}"

--- a/templates/panels.tmpl
+++ b/templates/panels.tmpl
@@ -20,7 +20,7 @@
         <label for="name-query" class="block text-sm/6 font-medium text-gray-900" title="Search for a panel with a specific name.">
             Name
         </label>
-        <input id="name-query" class="border-1 rounded-md border-gray-500 px-1" name="name-query" type="search" placeholder="Panel name" value="{{ .filter.Name }}" />
+        <input id="name-query" class="border-1 rounded-md border-gray-500 px-1" name="name_query" type="search" placeholder="Panel name" value="{{ .filter.Name }}" />
         <label for="gene" class="block text-sm/6 font-medium text-gray-900" title="Search for a panel containing a particular gene. Only exact matches will be returned (case insentitive).">
             Gene
         </label>

--- a/templates/panels.tmpl
+++ b/templates/panels.tmpl
@@ -77,7 +77,12 @@
 <header>
     <h3 class="text-2xl">
         {{ .panel.Name }} ({{ .panel.Genes | len }} genes)
-        {{ if .panel.Archived }}<span class="inline-block py-1 px-2 rounded-md bg-red-600 text-white">Archived</span>{{ end }}
+        {{ if .panel.Archived }}
+            <span class="inline-block py-1 px-2 rounded-md bg-red-600 text-white"
+                title="Archived at {{ .panel.ArchivedAt.Local.Format "2006-01-02 15:04 MST" }}">
+                Archived
+            </span>
+        {{ end }}
     </h3>
     <select class="my-2"
             name="version"

--- a/templates/panels.tmpl
+++ b/templates/panels.tmpl
@@ -109,7 +109,7 @@
     <tbody>
         {{ range .panel.Genes }}
         <tr class="hover:bg-accent-100 border-b border-gray-200">
-            <td class="px-2 text-left">{{ .Symbol }}</td>
+            <td class="px-2 text-left italic">{{ .Symbol }}</td>
             <td class="px-2 text-right"><a class="text-accent-900" href="https://genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:{{ .HGNC }}">{{ .HGNC }}</a></td>
         </tr>
         {{ end }}

--- a/templates/panels.tmpl
+++ b/templates/panels.tmpl
@@ -93,7 +93,7 @@
         <option
             value="{{ .Version }}"
             {{ if eq .Version $panelVersion }} selected{{ end }}>
-            v{{ .Version }} ({{ .Date.Format "2006-01-02" }})
+            v{{ .Version }} ({{ .Date.Local.Format "2006-01-02" }})
         </option>
         {{ end }}
     </select>
@@ -122,6 +122,6 @@
 <table>
 
 <p class="my-4 text-xs">
-    {{ .panel.Name }} v{{ .panel.Version }} created on {{ .panel.Date.Format "2006-01-02" }}
+    {{ .panel.Name }} v{{ .panel.Version }} created on {{ .panel.Date.Local.Format "2006-01-02" }}
 </p>
 {{ end }}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,80 @@
+package cleve
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major    int
+	Minor    int
+	Patch    int
+	hasPatch bool
+}
+
+func (v Version) HasPatch() bool {
+	return v.hasPatch
+}
+
+func (v Version) IsZero() bool {
+	return v.Major == 0 && v.Minor == 0 && v.Patch == 0
+}
+
+func (v Version) Equal(other Version) bool {
+	return v.Major == other.Major &&
+		v.Minor == other.Minor &&
+		v.Patch == other.Patch &&
+		v.hasPatch == other.hasPatch
+}
+
+func (v Version) String() string {
+	if v.hasPatch {
+		return fmt.Sprintf("%d.%d.%.d", v.Major, v.Minor, v.Patch)
+	}
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+func NewMinorVersion(major int, minor int) Version {
+	return Version{
+		Major:    major,
+		Minor:    minor,
+		hasPatch: false,
+	}
+}
+
+func NewPatchVersion(major int, minor int, patch int) Version {
+	return Version{
+		Major:    major,
+		Minor:    minor,
+		Patch:    patch,
+		hasPatch: true,
+	}
+}
+
+func ParseVersion(vs string) (Version, error) {
+	v := Version{
+		hasPatch: false,
+	}
+	elems := strings.Split(strings.TrimSpace(vs), ".")
+	if len(elems) < 2 || len(elems) > 3 {
+		return v, fmt.Errorf("invalid format for version: %q", vs)
+	}
+	nums := make([]int, len(elems))
+	for i := range len(elems) {
+		n, err := strconv.ParseUint(elems[i], 10, 32)
+		if err != nil {
+			return v, err
+		}
+		nums[i] = int(n)
+	}
+	switch len(nums) {
+	case 2:
+		v = NewMinorVersion(nums[0], nums[1])
+	case 3:
+		v = NewPatchVersion(nums[0], nums[1], nums[2])
+	default:
+		return v, fmt.Errorf("invalid number of elements in version: %v", nums)
+	}
+	return v, nil
+}

--- a/version.go
+++ b/version.go
@@ -21,6 +21,54 @@ func (v Version) IsZero() bool {
 	return v.Major == 0 && v.Minor == 0 && v.Patch == 0
 }
 
+// OlderThan checks if version `v` is older than verson `other`. Only returns
+// `true` if `v` is strictly smaller than `other`. If the versions are identical
+// `false` is returned. If one of the versions has a patch version number and the
+// other doesn't, false is returned.
+func (v Version) OlderThan(other Version) bool {
+	if v.hasPatch != other.hasPatch {
+		return false
+	}
+	if v.Major < other.Major {
+		return true
+	} else if v.Major != other.Major {
+		return false
+	}
+	if v.Minor < other.Minor {
+		return true
+	} else if v.Minor != other.Minor {
+		return false
+	}
+	if v.hasPatch && other.hasPatch && v.Patch < other.Patch {
+		return true
+	}
+	return false
+}
+
+// NewerThan checks if version `v` is newer than verson `other`. Only returns
+// `true` if `v` is strictly larger than `other`. If the versions are identical
+// `false` is returned. If one of the versions has a patch version number and the
+// other doesn't, false is returned.
+func (v Version) NewerThan(other Version) bool {
+	if v.hasPatch != other.hasPatch {
+		return false
+	}
+	if v.Major > other.Major {
+		return true
+	} else if v.Major != other.Major {
+		return false
+	}
+	if v.Minor > other.Minor {
+		return true
+	} else if v.Minor != other.Minor {
+		return false
+	}
+	if v.hasPatch && other.hasPatch && v.Patch > other.Patch {
+		return true
+	}
+	return false
+}
+
 func (v Version) Equal(other Version) bool {
 	return v.Major == other.Major &&
 		v.Minor == other.Minor &&

--- a/version.go
+++ b/version.go
@@ -29,8 +29,11 @@ func (v Version) Equal(other Version) bool {
 }
 
 func (v Version) String() string {
+	if v.IsZero() {
+		return ""
+	}
 	if v.hasPatch {
-		return fmt.Sprintf("%d.%d.%.d", v.Major, v.Minor, v.Patch)
+		return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 	}
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }

--- a/version.go
+++ b/version.go
@@ -38,6 +38,10 @@ func (v Version) String() string {
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }
 
+func (v Version) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(v.String())), nil
+}
+
 func NewMinorVersion(major int, minor int) Version {
 	return Version{
 		Major:    major,

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,153 @@
+package cleve
+
+import (
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	testcases := []struct {
+		name     string
+		string   string
+		estring  string
+		hasPatch bool
+		error    bool
+	}{
+		{
+			name:    "minor version",
+			string:  "1.5",
+			estring: "1.5",
+		},
+		{
+			name:     "patch version",
+			string:   "0.3.0",
+			estring:  "0.3.0",
+			hasPatch: true,
+		},
+		{
+			name:     "patch version with trailing whitespace",
+			string:   "1.0.0  ",
+			estring:  "1.0.0",
+			hasPatch: true,
+		},
+		{
+			name:     "patch version with leading whitespace",
+			string:   "\t5.0.3",
+			estring:  "5.0.3",
+			hasPatch: true,
+		},
+		{
+			name:   "too many elements",
+			string: "1.0.0.0",
+			error:  true,
+		},
+		{
+			name:   "too few elements",
+			string: "1",
+			error:  true,
+		},
+		{
+			name:   "missing elements",
+			string: "1.",
+			error:  true,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			v, err := ParseVersion(c.string)
+			if c.error != (err != nil) {
+				if c.error {
+					t.Errorf("expected error, got nil: %#v", v)
+				} else {
+					t.Errorf("expected no error, got this: %s", err.Error())
+				}
+			}
+			if c.hasPatch != v.hasPatch {
+				t.Errorf("expected hasPatch to be %t, got %t", c.hasPatch, v.hasPatch)
+			}
+		})
+	}
+}
+
+func TestVersionEquality(t *testing.T) {
+	testcases := []struct {
+		name  string
+		v1    string
+		v2    string
+		equal bool
+	}{
+		{
+			name:  "equal minor version",
+			v1:    "1.3",
+			v2:    "1.3",
+			equal: true,
+		},
+		{
+			name:  "equal patch version",
+			v1:    "1.3.10",
+			v2:    "1.3.10",
+			equal: true,
+		},
+		{
+			name:  "inequal minor version",
+			v1:    "1.3",
+			v2:    "1.4",
+			equal: false,
+		},
+		{
+			name:  "inequal patch version",
+			v1:    "1.3.1",
+			v2:    "1.4.1",
+			equal: false,
+		},
+		{
+			name:  "compare patch and minor",
+			v1:    "1.3.0",
+			v2:    "1.3",
+			equal: false,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			v1, _ := ParseVersion(c.v1)
+			v2, _ := ParseVersion(c.v2)
+			obs := v1.Equal(v2)
+			if v1.Equal(v2) != c.equal {
+				t.Errorf("expected equality to be %t, got %t", obs, c.equal)
+			}
+		})
+	}
+}
+
+func TestVersionIsZero(t *testing.T) {
+	testcases := []struct {
+		name   string
+		v      Version
+		isZero bool
+	}{
+		{
+			name:   "zero version",
+			v:      Version{},
+			isZero: true,
+		},
+		{
+			name:   "zero version with haspatch",
+			v:      Version{hasPatch: true},
+			isZero: true,
+		},
+		{
+			name:   "non-zero version",
+			v:      Version{Major: 1, hasPatch: true},
+			isZero: false,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.v.IsZero() != c.isZero {
+				t.Errorf("expected IsZero to be %t, got %t", c.isZero, c.v.IsZero())
+			}
+		})
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -158,3 +158,69 @@ func TestVersionIsZero(t *testing.T) {
 		})
 	}
 }
+
+func TestComparisons(t *testing.T) {
+	testcases := []struct {
+		name  string
+		v1    Version
+		v2    Version
+		older bool
+		newer bool
+	}{
+		{
+			name:  "minor version v1 older",
+			v1:    NewMinorVersion(1, 2),
+			v2:    NewMinorVersion(1, 3),
+			older: true,
+			newer: false,
+		},
+		{
+			name:  "minor version v1 newer",
+			v1:    NewMinorVersion(2, 3),
+			v2:    NewMinorVersion(1, 12),
+			older: false,
+			newer: true,
+		},
+		{
+			name:  "patch version v1 older",
+			v1:    NewPatchVersion(1, 2, 15),
+			v2:    NewPatchVersion(1, 3, 2),
+			older: true,
+			newer: false,
+		},
+		{
+			name:  "patch version v1 newer",
+			v1:    NewPatchVersion(1, 2, 15),
+			v2:    NewPatchVersion(1, 2, 2),
+			older: false,
+			newer: true,
+		},
+		{
+			name:  "compare minor version with patch version",
+			v1:    NewMinorVersion(2, 3),
+			v2:    NewPatchVersion(1, 12, 0),
+			older: false,
+			newer: false,
+		},
+		{
+			name:  "compare same version",
+			v1:    NewPatchVersion(2, 3, 5),
+			v2:    NewPatchVersion(2, 3, 5),
+			older: false,
+			newer: false,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			older := c.v1.OlderThan(c.v2)
+			newer := c.v1.NewerThan(c.v2)
+			if c.older != older {
+				t.Errorf("expected older to be %t", c.older)
+			}
+			if c.newer != newer {
+				t.Errorf("expected newer to be %t", c.newer)
+			}
+		})
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -125,21 +125,25 @@ func TestVersionIsZero(t *testing.T) {
 		name   string
 		v      Version
 		isZero bool
+		string string
 	}{
 		{
 			name:   "zero version",
 			v:      Version{},
 			isZero: true,
+			string: "",
 		},
 		{
 			name:   "zero version with haspatch",
 			v:      Version{hasPatch: true},
 			isZero: true,
+			string: "",
 		},
 		{
 			name:   "non-zero version",
 			v:      Version{Major: 1, hasPatch: true},
 			isZero: false,
+			string: "1.0.0",
 		},
 	}
 
@@ -147,6 +151,9 @@ func TestVersionIsZero(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if c.v.IsZero() != c.isZero {
 				t.Errorf("expected IsZero to be %t, got %t", c.isZero, c.v.IsZero())
+			}
+			if c.string != c.v.String() {
+				t.Errorf("expected version string %q, got %q", c.string, c.v.String())
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds *in silico* gene panels to Cleve. This includes space on the dashboard for viewing the panels, including links to external resources (currently only HGNC). It also includes CLI commands and API endpoints for fetching panels, uploading gene panels and archiving gene panels. More functionality will likely come in the future.

The versioning of the gene panels includes a new Version struct that makes it possible to control versions in a better way than just using strings. With this checks are in place that don't allow you to add a gene panel which:

- Has a more recent version
- Has a creation date that is more recent that the one being uploaded
- Has a creation date in the future
- The panel ID has been archived

I think I've caught the most obvious things that could cause confusion, but there's surely things that I have missed. This is a good start though.