### PR TITLE
feat: add plot for the index summary

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -344,6 +344,9 @@
   .flex-none {
     flex: none;
   }
+  .shrink-0 {
+    flex-shrink: 0;
+  }
   .table-auto {
     table-layout: auto;
   }
@@ -377,8 +380,14 @@
   .items-center {
     align-items: center;
   }
+  .items-start {
+    align-items: flex-start;
+  }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
+  }
+  .gap-6 {
+    gap: calc(var(--spacing) * 6);
   }
   .gap-12 {
     gap: calc(var(--spacing) * 12);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -217,6 +217,9 @@
   .relative {
     position: relative;
   }
+  .sticky {
+    position: sticky;
+  }
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
@@ -314,6 +317,9 @@
     width: .8em;
     height: .8em;
   }
+  .max-h-\[35lvh\] {
+    max-height: 35lvh;
+  }
   .max-h-lvh {
     max-height: 100lvh;
   }
@@ -399,6 +405,9 @@
   }
   .overflow-x-auto {
     overflow-x: auto;
+  }
+  .overflow-y-auto {
+    overflow-y: auto;
   }
   .overflow-y-scroll {
     overflow-y: scroll;

--- a/charts/charts.go
+++ b/charts/charts.go
@@ -10,9 +10,11 @@ import (
 )
 
 type RunStats[T interop.OptionalFloat | float64 | int] struct {
-	Data  []RunStat[T]
-	Label string
-	Type  string
+	Data   []RunStat[T]
+	XLabel string
+	YLabel string
+	Label  string
+	Type   string
 }
 
 // Use a pointer for the value so that missing values
@@ -75,6 +77,8 @@ func BarChart[T interop.OptionalFloat | float64 | int](d RunStats[T]) *charts.Ba
 	chart := charts.NewBar()
 	chart.SetGlobalOptions(
 		charts.WithTooltipOpts(opts.Tooltip{Show: true}),
+		charts.WithXAxisOpts(opts.XAxis{Name: d.XLabel}),
+		charts.WithYAxisOpts(opts.YAxis{Name: d.YLabel}),
 	)
 	xLabels := make([]string, 0)
 	barData := make([]opts.BarData, 0)

--- a/gin/router.go
+++ b/gin/router.go
@@ -179,6 +179,7 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 	r.GET("/qc", DashboardQCHandler(db))
 	r.GET("/qc/charts/global", GlobalChartsHandler(db))
 	r.GET("/qc/charts/run/:runId", RunChartsHandler(db))
+	r.GET("/qc/charts/run/:runId/index", IndexChartHandler(db))
 
 	hxEndpoints := r.Group("/")
 	hxEndpoints.Use(hxMiddleware())

--- a/gin/run_charts.go
+++ b/gin/run_charts.go
@@ -1,12 +1,70 @@
 package gin
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gmc-norr/cleve/charts"
 	"github.com/gmc-norr/cleve/mongo"
 )
+
+func IndexChartHandler(db *mongo.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := c.Request.ParseForm(); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		runId := c.Param("runId")
+		yData := c.Query("y")
+		d, err := db.RunQC(runId)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		plotData := charts.RunStats[float64]{
+			XLabel: "Sample",
+			Type:   "bar",
+		}
+		switch yData {
+		case "", "percent-pf-reads":
+			plotData.YLabel = "%PF Reads"
+		case "m-reads":
+			plotData.YLabel = "Reads (M)"
+		default:
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid data for y-axis: %s", yData)})
+			return
+		}
+		for _, s := range d.IndexSummary.Indexes {
+			datum := charts.RunStat[float64]{
+				RunID: s.Sample,
+			}
+			switch yData {
+			case "", "percent-pf-reads":
+				datum.Value = &s.PercentReads
+			case "m-reads":
+				mReads := float64(s.ReadCount) / 1e6
+				datum.Value = &mReads
+			}
+			plotData.Data = append(plotData.Data, datum)
+		}
+
+		p, err := plotData.Plot()
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if err := p.Render(c.Writer); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+}
 
 func RunChartsHandler(db RunQCGetter) gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -87,26 +87,40 @@
     {{ if not .qc.IndexSummary.Indexes }}
     <p>No indexing information found.</p>
     {{ else }}
-    <table class="my-6">
-        <thead class="bg-accent-900 text-accent-100">
-            <tr>
-                <th class="px-2">Sample</th>
-                <th class="px-2">Index</th>
-                <th class="px-2 text-right">Reads (M)</th>
-                <th class="px-2 text-right">% PF reads</th>
-            </tr>
-        </thead>
-        <tbody class="bg-accent-100">
-            {{ range $s := .qc.IndexSummary.Indexes }}
+    <div class="flex items-start gap-6 my-6">
+        <table class="shrink-0">
+            <thead class="bg-accent-900 text-accent-100">
                 <tr>
-                    <td class="px-2">{{ $s.Sample }}</td>
-                    <td class="px-2">{{ $s.Index }}</td>
-                    <td class="px-2 text-right">{{ toFloat $s.ReadCount | multiply 1e-6 | printf "%.2f" }}</td>
-                    <td class="px-2 text-right">{{ $s.PercentReads | printf "%.2f" }}</td>
+                    <th class="px-2">Sample</th>
+                    <th class="px-2">Index</th>
+                    <th class="px-2 text-right">Reads (M)</th>
+                    <th class="px-2 text-right">% PF reads</th>
                 </tr>
-            {{ end }}
-        </tbody>
-    </table>
+            </thead>
+            <tbody class="bg-accent-100">
+                {{ range $s := .qc.IndexSummary.Indexes }}
+                    <tr>
+                        <td class="px-2">{{ $s.Sample }}</td>
+                        <td class="px-2">{{ $s.Index }}</td>
+                        <td class="px-2 text-right">{{ toFloat $s.ReadCount | multiply 1e-6 | printf "%.2f" }}</td>
+                        <td class="px-2 text-right">{{ $s.PercentReads | printf "%.2f" }}</td>
+                    </tr>
+                {{ end }}
+            </tbody>
+        </table>
+        <div>
+            <form hx-get="/qc/charts/run/{{ .run.RunID }}/index" hx-trigger="change select[name=y]" hx-target="next div">
+                <label>
+                    Y-axis:
+                    <select class="border rounded-md" name="y">
+                        <option value="percent-pf-reads" selected>%PF Reads</option>
+                        <option value="m-reads">Number of reads (M)</option>
+                    </select>
+                </label>
+            </form>
+            <div hx-get="/qc/charts/run/{{ .run.RunID }}/index" hx-trigger="load" hx-include="select[name=y]"></div>
+        </div>
+    </div>
     {{ end }}
 </section>
 

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -88,26 +88,28 @@
     <p>No indexing information found.</p>
     {{ else }}
     <div class="flex items-start gap-6 my-6">
-        <table class="shrink-0">
-            <thead class="bg-accent-900 text-accent-100">
-                <tr>
-                    <th class="px-2">Sample</th>
-                    <th class="px-2">Index</th>
-                    <th class="px-2 text-right">Reads (M)</th>
-                    <th class="px-2 text-right">% PF reads</th>
-                </tr>
-            </thead>
-            <tbody class="bg-accent-100">
-                {{ range $s := .qc.IndexSummary.Indexes }}
-                    <tr>
-                        <td class="px-2">{{ $s.Sample }}</td>
-                        <td class="px-2">{{ $s.Index }}</td>
-                        <td class="px-2 text-right">{{ toFloat $s.ReadCount | multiply 1e-6 | printf "%.2f" }}</td>
-                        <td class="px-2 text-right">{{ $s.PercentReads | printf "%.2f" }}</td>
+        <div class="max-h-[35lvh] overflow-y-auto">
+            <table class="shrink-0">
+                <thead>
+                    <tr class="sticky top-0 bg-accent-900 text-accent-100">
+                        <th class="px-2">Sample</th>
+                        <th class="px-2">Index</th>
+                        <th class="px-2 text-right">Reads (M)</th>
+                        <th class="px-2 text-right">% PF reads</th>
                     </tr>
-                {{ end }}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="bg-accent-100">
+                    {{ range $s := .qc.IndexSummary.Indexes }}
+                        <tr>
+                            <td class="px-2">{{ $s.Sample }}</td>
+                            <td class="px-2">{{ $s.Index }}</td>
+                            <td class="px-2 text-right">{{ toFloat $s.ReadCount | multiply 1e-6 | printf "%.2f" }}</td>
+                            <td class="px-2 text-right">{{ $s.PercentReads | printf "%.2f" }}</td>
+                        </tr>
+                    {{ end }}
+                </tbody>
+            </table>
+        </div>
         <div>
             <form hx-get="/qc/charts/run/{{ .run.RunID }}/index" hx-trigger="change select[name=y]" hx-target="next div">
                 <label>


### PR DESCRIPTION
This PR adds a plot next to the indexing metrics on the run page. It allows the user to select between displaying the percentage of PF reads and the number of reads (in millions). In addition the height of the index table has been limited and will enable scrolling if it exceeds the limit.