### PR TITLE
fix: ignore page title when fetching index plots

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -317,8 +317,8 @@
     width: .8em;
     height: .8em;
   }
-  .max-h-\[35lvh\] {
-    max-height: 35lvh;
+  .max-h-\[50lvh\] {
+    max-height: 50lvh;
   }
   .max-h-lvh {
     max-height: 100lvh;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -507,6 +507,9 @@
   .text-right {
     text-align: right;
   }
+  .font-mono {
+    font-family: var(--font-mono);
+  }
   .text-2xl {
     font-size: var(--text-2xl);
     line-height: var(--tw-leading, var(--text-2xl--line-height));

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -88,8 +88,8 @@
     <p>No indexing information found.</p>
     {{ else }}
     <div class="flex items-start gap-6 my-6">
-        <div class="max-h-[35lvh] overflow-y-auto">
-            <table class="shrink-0">
+        <div class="max-h-[35lvh] overflow-y-auto shrink-0">
+            <table class="w-full">
                 <thead>
                     <tr class="sticky top-0 bg-accent-900 text-accent-100">
                         <th class="px-2">Sample</th>

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -102,7 +102,7 @@
                     {{ range $s := .qc.IndexSummary.Indexes }}
                         <tr>
                             <td class="px-2">{{ $s.Sample }}</td>
-                            <td class="px-2">{{ $s.Index }}</td>
+                            <td class="px-2 font-mono">{{ $s.Index }}</td>
                             <td class="px-2 text-right">{{ toFloat $s.ReadCount | multiply 1e-6 | printf "%.2f" }}</td>
                             <td class="px-2 text-right">{{ $s.PercentReads | printf "%.2f" }}</td>
                         </tr>

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -88,7 +88,7 @@
     <p>No indexing information found.</p>
     {{ else }}
     <div class="flex items-start gap-6 my-6">
-        <div class="max-h-[35lvh] overflow-y-auto shrink-0">
+        <div class="max-h-[50lvh] overflow-y-auto shrink-0">
             <table class="w-full">
                 <thead>
                     <tr class="sticky top-0 bg-accent-900 text-accent-100">

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -111,7 +111,11 @@
             </table>
         </div>
         <div>
-            <form hx-get="/qc/charts/run/{{ .run.RunID }}/index" hx-trigger="change select[name=y]" hx-target="next div">
+            <form
+                hx-get="/qc/charts/run/{{ .run.RunID }}/index"
+                hx-trigger="change"
+                hx-swap="innerHTML ignoreTitle:true"
+                hx-target="next div">
                 <label>
                     Y-axis:
                     <select class="border rounded-md" name="y">
@@ -120,7 +124,12 @@
                     </select>
                 </label>
             </form>
-            <div hx-get="/qc/charts/run/{{ .run.RunID }}/index" hx-trigger="load" hx-include="select[name=y]"></div>
+            <div
+                hx-get="/qc/charts/run/{{ .run.RunID }}/index"
+                hx-trigger="load"
+                hx-swap="innerHTML ignoreTitle:true"
+                hx-include="select[name=y]">
+            </div>
         </div>
     </div>
     {{ end }}


### PR DESCRIPTION
This PR fixes an issue where the title of the index plot would be used for the page title when fetched. Now the title is ignored.

In addition to this some minor styling adjustments of the index table were made.