### PR TITLE
feat: add loading indicators to plots

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -406,6 +406,9 @@
   .grid-rows-1 {
     grid-template-rows: repeat(1, minmax(0, 1fr));
   }
+  .flex-col {
+    flex-direction: column;
+  }
   .flex-wrap {
     flex-wrap: wrap;
   }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,6 +13,7 @@
     --color-green-600: oklch(62.7% 0.194 149.214);
     --color-slate-200: oklch(92.9% 0.013 255.508);
     --color-slate-300: oklch(86.9% 0.022 252.894);
+    --color-slate-400: oklch(70.4% 0.04 256.788);
     --color-slate-500: oklch(55.4% 0.046 257.417);
     --color-slate-600: oklch(44.6% 0.043 257.281);
     --color-gray-200: oklch(92.8% 0.006 264.531);
@@ -199,6 +200,9 @@
   }
 }
 @layer utilities {
+  .pointer-events-none {
+    pointer-events: none;
+  }
   .collapse {
     visibility: collapse;
   }
@@ -225,6 +229,12 @@
   }
   .right-0 {
     right: calc(var(--spacing) * 0);
+  }
+  .isolate {
+    isolation: isolate;
+  }
+  .z-10 {
+    z-index: 10;
   }
   .container {
     width: 100%;
@@ -317,11 +327,21 @@
     width: .8em;
     height: .8em;
   }
+  .size-\[\.8lh\] {
+    width: .8lh;
+    height: .8lh;
+  }
+  .h-full {
+    height: 100%;
+  }
   .max-h-\[50lvh\] {
     max-height: 50lvh;
   }
   .max-h-lvh {
     max-height: 100lvh;
+  }
+  .min-h-\[500px\] {
+    min-height: 500px;
   }
   .w-fit {
     width: fit-content;
@@ -331,6 +351,9 @@
   }
   .max-w-4xl {
     max-width: var(--container-4xl);
+  }
+  .max-w-\[900px\] {
+    max-width: 900px;
   }
   .max-w-fit {
     max-width: fit-content;
@@ -343,6 +366,9 @@
   }
   .min-w-3xs {
     min-width: var(--container-3xs);
+  }
+  .min-w-\[900px\] {
+    min-width: 900px;
   }
   .min-w-fit {
     min-width: fit-content;
@@ -388,6 +414,9 @@
   }
   .items-start {
     align-items: flex-start;
+  }
+  .justify-center {
+    justify-content: center;
   }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
@@ -467,6 +496,12 @@
   }
   .bg-slate-200 {
     background-color: var(--color-slate-200);
+  }
+  .bg-slate-400\/25 {
+    background-color: color-mix(in srgb, oklch(70.4% 0.04 256.788) 25%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-slate-400) 25%, transparent);
+    }
   }
   .bg-slate-500 {
     background-color: var(--color-slate-500);

--- a/charts/charts.go
+++ b/charts/charts.go
@@ -84,6 +84,7 @@ func LineChart[T interop.OptionalFloat | float64 | int](d RunStats[T]) *charts.L
 func BarChart[T interop.OptionalFloat | float64 | int](d RunStats[T]) *charts.Bar {
 	chart := charts.NewBar()
 	chart.SetGlobalOptions(
+		charts.WithInitializationOpts(opts.Initialization{Width: "900px", Height: "500px"}),
 		charts.WithTooltipOpts(opts.Tooltip{Show: opts.Bool(true)}),
 		charts.WithXAxisOpts(opts.XAxis{Name: d.XLabel}),
 		charts.WithYAxisOpts(opts.YAxis{Name: d.YLabel}),
@@ -114,6 +115,7 @@ func ScatterChart[T cmp.Ordered](d ScatterData[T]) *charts.Scatter {
 		yOpts.Max = d.YLimit[1]
 	}
 	chart.SetGlobalOptions(
+		charts.WithInitializationOpts(opts.Initialization{Width: "900px", Height: "500px"}),
 		charts.WithLegendOpts(opts.Legend{Show: opts.Bool(true)}),
 		charts.WithTooltipOpts(opts.Tooltip{Show: opts.Bool(true)}),
 		charts.WithXAxisOpts(xOpts),

--- a/templates/qc.tmpl
+++ b/templates/qc.tmpl
@@ -7,7 +7,7 @@
 <section id="run-qc-chart" class="mx-6 my-8">
     <h2 class="text-3xl my-4">Charts</h2>
     <div>
-        <form id="chart-form"
+        <form class="flex gap-2" id="chart-form"
             autocomplete="off"
             hx-get="/qc/charts/global"
             hx-target="#chart-container"
@@ -17,16 +17,20 @@
             hx-indicator="#chart-spinner">
             <input type="hidden" name="page_size" value="{{ .filter.PageSize }}" />
             <input type="hidden" name="page" value="{{ .filter.Page }}" />
-            <label for="chart-data-select">Chart type:</label>
-            <select id="chart-data-select" name="chart-data">
-                <option value="q30"{{ if eq .chart_config.ChartData "q30" }} selected{{ end }}>%&ge;Q30</option>
-                <option value="error_rate"{{ if eq .chart_config.ChartData "error_rate" }} selected{{ end }}>Error rate</option>
-            </select>
-            <label for="chart-type-select">Chart type:</label>
-            <select id="chart-type-select" name="chart-type">
-                <option value="bar"{{ if eq .chart_config.ChartData "bar" }} selected{{ end }}>Bar chart</option>
-                <option value="line"{{ if eq .chart_config.ChartType "line" }} selected{{ end }}>Line chart</option>
-            </select>
+            <label class="flex flex-col">
+                <span class="text-sm font-bold">Chart data</span>
+                <select id="chart-data-select" class="border rounded-md" name="chart-data">
+                    <option value="q30"{{ if eq .chart_config.ChartData "q30" }} selected{{ end }}>%&ge;Q30</option>
+                    <option value="error_rate"{{ if eq .chart_config.ChartData "error_rate" }} selected{{ end }}>Error rate</option>
+                </select>
+            </label>
+            <label class="flex flex-col">
+                <span class="text-sm font-bold">Chart type</span>
+                <select id="chart-type-select" class="border rounded-md" name="chart-type">
+                    <option value="bar"{{ if eq .chart_config.ChartData "bar" }} selected{{ end }}>Bar chart</option>
+                    <option value="line"{{ if eq .chart_config.ChartType "line" }} selected{{ end }}>Line chart</option>
+                </select>
+            </label>
         </form>
         <div class="relative isolate max-w-[900px] min-h-[500px]">
             <div id="chart-spinner" class="bg-slate-400/25 absolute pointer-events-none w-full h-full htmx-indicator flex items-center justify-center z-10">

--- a/templates/qc.tmpl
+++ b/templates/qc.tmpl
@@ -6,32 +6,40 @@
 
 <section id="run-qc-chart" class="mx-6 my-8">
     <h2 class="text-3xl my-4">Charts</h2>
-    <form id="chart-form"
-        autocomplete="off"
-        hx-get="/qc/charts/global"
-        hx-target="#chart-container"
-        hx-trigger="change, keyup delay:300ms from:input[name=run_id_query], change from:select[name=platform]"
-        hx-swap="innerHtml ignoreTitle:true"
-        hx-include="#table-form">
-        <input type="hidden" name="page_size" value="{{ .filter.PageSize }}" />
-        <input type="hidden" name="page" value="{{ .filter.Page }}" />
-        <label for="chart-data-select">Chart type:</label>
-        <select id="chart-data-select" name="chart-data">
-            <option value="q30"{{ if eq .chart_config.ChartData "q30" }} selected{{ end }}>%&ge;Q30</option>
-            <option value="error_rate"{{ if eq .chart_config.ChartData "error_rate" }} selected{{ end }}>Error rate</option>
-        </select>
-        <label for="chart-type-select">Chart type:</label>
-        <select id="chart-type-select" name="chart-type">
-            <option value="bar"{{ if eq .chart_config.ChartData "bar" }} selected{{ end }}>Bar chart</option>
-            <option value="line"{{ if eq .chart_config.ChartType "line" }} selected{{ end }}>Line chart</option>
-        </select>
-    </form>
-    <div id="chart-container"
-        hx-get="/qc/charts/global"
-        hx-include="#chart-form,#qc-table-form"
-        hx-trigger="load"
-        hx-swap="innerHTML ignoreTitle:true">
-        <p>Loading chart...</p>
+    <div>
+        <form id="chart-form"
+            autocomplete="off"
+            hx-get="/qc/charts/global"
+            hx-target="#chart-container"
+            hx-trigger="change, keyup delay:300ms from:input[name=run_id_query], change from:select[name=platform]"
+            hx-swap="innerHtml ignoreTitle:true"
+            hx-include="#table-form"
+            hx-indicator="#chart-spinner">
+            <input type="hidden" name="page_size" value="{{ .filter.PageSize }}" />
+            <input type="hidden" name="page" value="{{ .filter.Page }}" />
+            <label for="chart-data-select">Chart type:</label>
+            <select id="chart-data-select" name="chart-data">
+                <option value="q30"{{ if eq .chart_config.ChartData "q30" }} selected{{ end }}>%&ge;Q30</option>
+                <option value="error_rate"{{ if eq .chart_config.ChartData "error_rate" }} selected{{ end }}>Error rate</option>
+            </select>
+            <label for="chart-type-select">Chart type:</label>
+            <select id="chart-type-select" name="chart-type">
+                <option value="bar"{{ if eq .chart_config.ChartData "bar" }} selected{{ end }}>Bar chart</option>
+                <option value="line"{{ if eq .chart_config.ChartType "line" }} selected{{ end }}>Line chart</option>
+            </select>
+        </form>
+        <div class="relative isolate max-w-[900px] min-h-[500px]">
+            <div id="chart-spinner" class="bg-slate-400/25 absolute pointer-events-none w-full h-full htmx-indicator flex items-center justify-center z-10">
+                <span class="flex items-center gap-2 text-4xl"><img class="inline-block size-[.8lh] animate-spin" src="/static/img/spinner.svg"> Loading chart...</span>
+            </div>
+            <div id="chart-container"
+                hx-get="/qc/charts/global"
+                hx-include="#chart-form,#qc-table-form"
+                hx-trigger="load"
+                hx-swap="innerHTML ignoreTitle:true"
+                hx-indicator="#chart-spinner">
+            </div>
+        </div>
     </div>
 </section>
 <script src="/static/js/echarts.min.js"></script>

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -112,13 +112,14 @@
         </div>
         <div>
             <form
+                class="flex gap-2"
                 hx-get="/qc/charts/run/{{ .run.RunID }}/index"
                 hx-trigger="change"
                 hx-swap="innerHTML ignoreTitle:true"
                 hx-target="#index-chart-container"
                 hx-indicator="#index-chart-spinner">
-                <label>
-                    Y-axis:
+                <label class="flex flex-col">
+                    <span class="text-sm font-bold">Y-axis:</span>
                     <select class="border rounded-md" name="y">
                         <option value="percent-pf-reads" selected>%PF Reads</option>
                         <option value="m-reads">Number of reads (M)</option>
@@ -250,31 +251,41 @@
 
     {{ if .hasQc }}
     <div>
-        <form id="chart-form"
+        <form
+            class="flex gap-2"
+            id="chart-form"
             autocomplete="off"
             hx-get="/qc/charts/run/{{ .run.RunID }}"
             hx-target="#run-chart-container"
             hx-trigger="change"
             hx-indicator="#run-chart-spinner"
             hx-swap="innerHtml ignoreTitle:true">
-            <label for="chart-data-x-select">X-axis:</label>
-            <select id="chart-data-x-select" name="chart-data-x">
-                <option value="percent_occupied"{{ if eq .chart_config.XData "percent_occupied" }} selected{{ end }}>% occupied</option>
-                <option value="percent_pf"{{ if eq .chart_config.XData "percent_pf" }} selected{{ end }}>% passing filter</option>
-            </select>
-            <label for="chart-data-y-select">Y-axis:</label>
-            <select id="chart-data-y-select" name="chart-data-y">
-                <option value="percent_occupied"{{ if eq .chart_config.YData "percent_occupied" }} selected{{ end }}>% occupied</option>
-                <option value="percent_pf"{{ if eq .chart_config.YData "percent_pf" }} selected{{ end }}>% passing filter</option>
-            </select>
-            <label for="chart-type-select">Chart type:</label>
-            <select id="chart-type-select" name="chart-type">
-                <option value="scatter"{{ if eq .chart_config.ChartType "scatter" }} selected{{ end }}>Scatter plot</option>
-            </select>
-            <label for="chart-color-by-select">Color by:</label>
-            <select id="chart-color-by-select" name="chart-color-by">
-                <option value="lane"{{ if eq .chart_config.ColorBy "lane" }} selected{{ end }}>Lane</option>
-            </select>
+            <label class="flex flex-col">
+                <span class="text-sm font-bold">X-axis</span>
+                <select id="chart-data-x-select" class="border rounded-md" name="chart-data-x">
+                    <option value="percent_occupied"{{ if eq .chart_config.XData "percent_occupied" }} selected{{ end }}>% occupied</option>
+                    <option value="percent_pf"{{ if eq .chart_config.XData "percent_pf" }} selected{{ end }}>% passing filter</option>
+                </select>
+            </label>
+            <label class="flex flex-col">
+                <span class="text-sm font-bold">Y-axis</span>
+                <select id="chart-data-y-select" class="border rounded-md" name="chart-data-y">
+                    <option value="percent_occupied"{{ if eq .chart_config.YData "percent_occupied" }} selected{{ end }}>% occupied</option>
+                    <option value="percent_pf"{{ if eq .chart_config.YData "percent_pf" }} selected{{ end }}>% passing filter</option>
+                </select>
+            </label>
+            <label class="flex flex-col">
+                <span class="text-sm font-bold">Chart type</span>
+                <select id="chart-type-select" class="border rounded-md" name="chart-type">
+                    <option value="scatter"{{ if eq .chart_config.ChartType "scatter" }} selected{{ end }}>Scatter plot</option>
+                </select>
+            </label>
+            <label class="flex flex-col">
+                <span class="text-sm font-bold">Color by</span>
+                <select id="chart-color-by-select" class="border rounded-md" name="chart-color-by">
+                    <option value="lane"{{ if eq .chart_config.ColorBy "lane" }} selected{{ end }}>Lane</option>
+                </select>
+            </label>
         </form>
         <div class="relative isolate max-w-[900px] min-h-[500px]">
             <div id="run-chart-spinner" class="bg-slate-400/25 absolute pointer-events-none w-full h-full htmx-indicator flex items-center justify-center z-10">

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -115,7 +115,8 @@
                 hx-get="/qc/charts/run/{{ .run.RunID }}/index"
                 hx-trigger="change"
                 hx-swap="innerHTML ignoreTitle:true"
-                hx-target="next div">
+                hx-target="#index-chart-container"
+                hx-indicator="#index-chart-spinner">
                 <label>
                     Y-axis:
                     <select class="border rounded-md" name="y">
@@ -124,11 +125,18 @@
                     </select>
                 </label>
             </form>
-            <div
-                hx-get="/qc/charts/run/{{ .run.RunID }}/index"
-                hx-trigger="load"
-                hx-swap="innerHTML ignoreTitle:true"
-                hx-include="select[name=y]">
+            <div class="relative isolate min-w-[900px] min-h-[500px]">
+                <div id="index-chart-spinner" class="bg-slate-400/25 absolute pointer-events-none w-full h-full htmx-indicator flex items-center justify-center z-10">
+                    <span class="flex items-center gap-2 text-4xl"><img class="inline-block size-[.8lh] animate-spin" src="/static/img/spinner.svg"> Loading chart...</span>
+                </div>
+                <div
+                    id="index-chart-container"
+                    hx-get="/qc/charts/run/{{ .run.RunID }}/index"
+                    hx-trigger="load"
+                    hx-swap="innerHTML ignoreTitle:true"
+                    hx-include="select[name=y]"
+                    hx-indicator="#index-chart-spinner">
+                </div>
             </div>
         </div>
     </div>
@@ -241,38 +249,45 @@
     <h2 class="text-2xl my-4">Charts</h2>
 
     {{ if .hasQc }}
-    <form id="chart-form"
-        autocomplete="off"
-        hx-get="/qc/charts/run/{{ .run.RunID }}"
-        hx-target="#chart-container"
-        hx-trigger="change"
-        hx-swap="innerHtml ignoreTitle:true"
-        hx-include="#qc-table-form">
-        <label for="chart-data-x-select">X-axis:</label>
-        <select id="chart-data-x-select" name="chart-data-x">
-            <option value="percent_occupied"{{ if eq .chart_config.XData "percent_occupied" }} selected{{ end }}>% occupied</option>
-            <option value="percent_pf"{{ if eq .chart_config.XData "percent_pf" }} selected{{ end }}>% passing filter</option>
-        </select>
-        <label for="chart-data-y-select">Y-axis:</label>
-        <select id="chart-data-y-select" name="chart-data-y">
-            <option value="percent_occupied"{{ if eq .chart_config.YData "percent_occupied" }} selected{{ end }}>% occupied</option>
-            <option value="percent_pf"{{ if eq .chart_config.YData "percent_pf" }} selected{{ end }}>% passing filter</option>
-        </select>
-        <label for="chart-type-select">Chart type:</label>
-        <select id="chart-type-select" name="chart-type">
-            <option value="scatter"{{ if eq .chart_config.ChartType "scatter" }} selected{{ end }}>Scatter plot</option>
-        </select>
-        <label for="chart-color-by-select">Color by:</label>
-        <select id="chart-color-by-select" name="chart-color-by">
-            <option value="lane"{{ if eq .chart_config.ColorBy "lane" }} selected{{ end }}>Lane</option>
-        </select>
-    </form>
-    <div id="chart-container"
-        hx-get="/qc/charts/run/{{ .run.RunID }}"
-        hx-include="#chart-form,#qc-table-form"
-        hx-trigger="load"
-        hx-swap="innerHTML ignoreTitle:true">
-        <p>Loading chart...</p>
+    <div>
+        <form id="chart-form"
+            autocomplete="off"
+            hx-get="/qc/charts/run/{{ .run.RunID }}"
+            hx-target="#run-chart-container"
+            hx-trigger="change"
+            hx-indicator="#run-chart-spinner"
+            hx-swap="innerHtml ignoreTitle:true">
+            <label for="chart-data-x-select">X-axis:</label>
+            <select id="chart-data-x-select" name="chart-data-x">
+                <option value="percent_occupied"{{ if eq .chart_config.XData "percent_occupied" }} selected{{ end }}>% occupied</option>
+                <option value="percent_pf"{{ if eq .chart_config.XData "percent_pf" }} selected{{ end }}>% passing filter</option>
+            </select>
+            <label for="chart-data-y-select">Y-axis:</label>
+            <select id="chart-data-y-select" name="chart-data-y">
+                <option value="percent_occupied"{{ if eq .chart_config.YData "percent_occupied" }} selected{{ end }}>% occupied</option>
+                <option value="percent_pf"{{ if eq .chart_config.YData "percent_pf" }} selected{{ end }}>% passing filter</option>
+            </select>
+            <label for="chart-type-select">Chart type:</label>
+            <select id="chart-type-select" name="chart-type">
+                <option value="scatter"{{ if eq .chart_config.ChartType "scatter" }} selected{{ end }}>Scatter plot</option>
+            </select>
+            <label for="chart-color-by-select">Color by:</label>
+            <select id="chart-color-by-select" name="chart-color-by">
+                <option value="lane"{{ if eq .chart_config.ColorBy "lane" }} selected{{ end }}>Lane</option>
+            </select>
+        </form>
+        <div class="relative isolate max-w-[900px] min-h-[500px]">
+            <div id="run-chart-spinner" class="bg-slate-400/25 absolute pointer-events-none w-full h-full htmx-indicator flex items-center justify-center z-10">
+                <span class="flex items-center gap-2 text-4xl"><img class="inline-block size-[.8lh] animate-spin" src="/static/img/spinner.svg"> Loading chart...</span>
+            </div>
+            <div id="run-chart-container"
+                hx-get="/qc/charts/run/{{ .run.RunID }}"
+                hx-include="#chart-form"
+                hx-trigger="load"
+                hx-indicator="#run-chart-spinner"
+                hx-swap="innerHTML ignoreTitle:true">
+            </div>
+        </div>
     </div>
     {{ else if eq $state "ready" }}
     <p>QC data has yet to be imported for this run.</p>


### PR DESCRIPTION
This PR adds loading indicators to the various plots in cleve. All of them are fetched asynchronously, and there was previously no indication that anything was happening. This has now been addressed.

A couple more things have also been fixed:

- The size of the plot is set when fetching them, and this is also done on the containing element. This will prevent things from jumping around too much when the plots are loaded.
- The plot controls have gotten better styling.