### PR TITLE
feat: simplify run update endpoint

### DIFF
--- a/cleve_api.yaml
+++ b/cleve_api.yaml
@@ -79,7 +79,7 @@ endpoints:
   - path: /runs/{run_id}/state
     method: PATCH
     section: runs
-    description: Update the state of a run
+    description: (deprecated) Update the state of a run
     headers:
       - key: Authorization
         type: string
@@ -98,7 +98,7 @@ endpoints:
   - path: /runs/{run_id}/path
     method: PATCH
     section: runs
-    description: Update the path of a run
+    description: (deprecated) Update the path of a run
     headers:
       - key: Authorization
         type: string
@@ -113,6 +113,29 @@ endpoints:
         type: string
         description: new path of the run directory
         required: true
+
+  - path: /runs/{run_id}
+    method: PATCH
+    section: runs
+    description: Update one or more run attributes
+    headers:
+      - key: Authorization
+        type: string
+        description: API key
+        required: true
+    params:
+      - key: run_id
+        type: string
+        description: ID of the run to update
+        required: true
+      - key: path
+        type: string
+        description: new path of the run directory
+        required: false
+      - key: state
+        type: string
+        description: new state of the run directory
+        required: false
 
   - path: /runs/{run_id}/analysis
     method: GET

--- a/gin/router.go
+++ b/gin/router.go
@@ -213,6 +213,7 @@ func NewRouter(db *mongo.DB, debug bool) http.Handler {
 	authEndpoints.POST("/api/runs", AddRunHandler(db))
 	authEndpoints.POST("/api/runs/:runId/analysis", AddAnalysisHandler(db))
 	authEndpoints.PATCH("/api/runs/:runId/analysis/:analysisId", UpdateAnalysisHandler(db))
+	authEndpoints.PATCH("/api/runs/:runId", UpdateRunHandler(db))
 	authEndpoints.PATCH("/api/runs/:runId/path", UpdateRunPathHandler(db))
 	authEndpoints.PATCH("/api/runs/:runId/state", UpdateRunStateHandler(db))
 	authEndpoints.POST("/api/runs/:runId/samplesheet", AddRunSampleSheetHandler(db))


### PR DESCRIPTION
This PR deprecates the two previous endpoints for updating the state and the path of a run. This is now baked into a single endpoint, similar to how analyses are handled.

In addition to this, the path of associated analyses are also updated if the original path of the analysis is a subdirectory of the original run path. It is then assumed that if the run is moved, any subdirectories are moved with it. It will still allow for single analyses being moved independently of the other run data.

Some improvements when it comes to the responsibility of keeping track of these things is warranted. For now I will say that this closes #98, but it could definitely be better.