### PR TITLE
ci: update golangci lint to v2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: generate
         run: go generate ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: v2.1.6

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,12 @@
+version: "2"
 linters:
-  disable-all: true
   enable:
-    - gofumpt
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
+formatters:
+  enable:
+    - gofumpt
     - goimports
-issues:
-  fix: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,3 +10,5 @@ formatters:
   enable:
     - gofumpt
     - goimports
+issues:
+  fix: true

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -382,6 +382,9 @@
   .flex-none {
     flex: none;
   }
+  .shrink {
+    flex-shrink: 1;
+  }
   .shrink-0 {
     flex-shrink: 0;
   }

--- a/cmd/cleve/panel/add.go
+++ b/cmd/cleve/panel/add.go
@@ -1,6 +1,7 @@
 package panel
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +45,11 @@ over what is in the file.
 		fileType, _ := cmd.Flags().GetString("filetype")
 		f, err := os.Open(args[0])
 		cobra.CheckErr(err)
-		defer f.Close()
+		defer func() {
+			if err := f.Close(); err != nil {
+				slog.Error("failed to close file", "error", err)
+			}
+		}()
 
 		var (
 			parseError error

--- a/cmd/cleve/panel/list.go
+++ b/cmd/cleve/panel/list.go
@@ -28,12 +28,12 @@ var listCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		w := tabwriter.NewWriter(os.Stdout, 5, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "id\tname\tversion\tarchived")
-		fmt.Fprintln(w, "--\t----\t-------\t--------")
+		_, _ = fmt.Fprintln(w, "id\tname\tversion\tarchived")
+		_, _ = fmt.Fprintln(w, "--\t----\t-------\t--------")
 		for _, p := range panels {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%t\n", p.Id, p.Name, p.Version.String(), p.Archived)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%t\n", p.Id, p.Name, p.Version.String(), p.Archived)
 		}
-		w.Flush()
+		_ = w.Flush()
 	},
 }
 

--- a/cmd/cleve/platform/list.go
+++ b/cmd/cleve/platform/list.go
@@ -35,12 +35,12 @@ var (
 				fmt.Println(string(jsonString))
 			} else {
 				w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-				fmt.Fprint(w, "name\tinstrument ids\trun count\tready marker\taliases\n")
-				fmt.Fprint(w, "----\t--------------\t---------\t------------\t-------\n")
+				_, _ = fmt.Fprint(w, "name\tinstrument ids\trun count\tready marker\taliases\n")
+				_, _ = fmt.Fprint(w, "----\t--------------\t---------\t------------\t-------\n")
 				for _, p := range platforms.Platforms {
-					fmt.Fprintf(w, "%s\t%v\t%d\t%s\t%v\n", p.Name, p.InstrumentIds, p.RunCount, p.ReadyMarker, p.Aliases)
+					_, _ = fmt.Fprintf(w, "%s\t%v\t%d\t%s\t%v\n", p.Name, p.InstrumentIds, p.RunCount, p.ReadyMarker, p.Aliases)
 				}
-				w.Flush()
+				_ = w.Flush()
 			}
 		},
 	}

--- a/gin/panels.go
+++ b/gin/panels.go
@@ -104,7 +104,7 @@ func AddPanelHandler(db *mongo.DB) gin.HandlerFunc {
 				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "a panel with this id and version already exists"})
 				return
 			}
-			if errors.Is(err, mongo.ConflictError) {
+			if errors.Is(err, mongo.ErrConflict) {
 				c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": err.Error(), "id": p.Id})
 				return
 			}

--- a/interop/corrected_intensity.go
+++ b/interop/corrected_intensity.go
@@ -145,7 +145,7 @@ func ReadCorrectedIntensity(filename string) (CorrectedIntensity, error) {
 	if err != nil {
 		return ci, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	r := bufio.NewReader(f)
 	return ParseCorrectedIntensity(r)
 }

--- a/interop/error_metrics.go
+++ b/interop/error_metrics.go
@@ -39,7 +39,7 @@ func parseErrorMetricRecordsV3(r io.Reader, em *ErrorMetrics) error {
 			return err
 		}
 		em.Records = append(em.Records, ErrorMetricRecord{
-			LTC:       rec.ltc1.normalize(),
+			LTC:       rec.normalize(),
 			ErrorRate: float64(rec.ErrorRate),
 		})
 	}
@@ -79,7 +79,7 @@ func parseErrorMetricRecordsV6(r io.Reader, adapterCount int, em *ErrorMetrics) 
 			return err
 		}
 		em.Records = append(em.Records, ErrorMetricRecord{
-			LTC:       rec.ltc2.normalize(),
+			LTC:       rec.normalize(),
 			ErrorRate: float64(rec.ErrorRate),
 		})
 	}
@@ -110,7 +110,7 @@ func ReadErrorMetrics(path string) (ErrorMetrics, error) {
 	if err != nil {
 		return em, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	r := bufio.NewReader(f)
 
 	err = binary.Read(r, binary.LittleEndian, &em.Header)

--- a/interop/extended_tilemetrics.go
+++ b/interop/extended_tilemetrics.go
@@ -53,7 +53,7 @@ func parseExtendedTileMetricRecordsV3(r io.Reader, tm *ExtTileMetrics) error {
 			return err
 		}
 		tm.Records = append(tm.Records, ExtTileMetricRecord{
-			LT:               rec.lt2.normalize(),
+			LT:               rec.normalize(),
 			OccupiedClusters: int(rec.OccupiedCount),
 		})
 	}
@@ -84,7 +84,7 @@ func parseExtendedTileMetricRecordsV1(r io.Reader, tm *ExtTileMetrics) error {
 		switch rec.Code {
 		case TileClusterCountOccupied:
 			tm.Records = append(tm.Records, ExtTileMetricRecord{
-				LT:               rec.lt1.normalize(),
+				LT:               rec.normalize(),
 				OccupiedClusters: int(rec.Value),
 			})
 		default:
@@ -104,20 +104,20 @@ func ReadExtendedTileMetrics(filename string) (ExtTileMetrics, error) {
 	if err != nil {
 		return tm, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	r := bufio.NewReader(f)
 	tm.Header, err = parseHeader(r)
 	if err != nil {
 		return tm, nil
 	}
 
-	switch tm.Header.Version {
+	switch tm.Version {
 	case 1:
 		err = parseExtendedTileMetricsV1(r, &tm)
 	case 3:
 		err = parseExtendedTileMetricsV3(r, &tm)
 	default:
-		return tm, fmt.Errorf("unsupported extended tile metrics version: %d", tm.Header.Version)
+		return tm, fmt.Errorf("unsupported extended tile metrics version: %d", tm.Version)
 	}
 
 	return tm, err

--- a/interop/index_metrics.go
+++ b/interop/index_metrics.go
@@ -101,7 +101,7 @@ func parseIndexMetricsV1(r io.Reader, im *IndexMetrics) error {
 		}
 
 		im.Records = append(im.Records, IndexMetricRecord{
-			LT:           rec.lt1.normalize(),
+			LT:           rec.normalize(),
 			Read:         int(rec.Read),
 			IndexName:    string(rec.IndexName),
 			SampleName:   string(rec.SampleName),
@@ -151,7 +151,7 @@ func parseIndexMetricsV2(r io.Reader, im *IndexMetrics) error {
 		}
 
 		im.Records = append(im.Records, IndexMetricRecord{
-			LT:           rec.lt2.normalize(),
+			LT:           rec.normalize(),
 			Read:         int(rec.Read),
 			IndexName:    string(rec.IndexName),
 			SampleName:   string(rec.SampleName),
@@ -168,7 +168,7 @@ func ReadIndexMetrics(path string) (IndexMetrics, error) {
 	if err != nil {
 		return im, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	r := bufio.NewReader(f)
 

--- a/interop/interop.go
+++ b/interop/interop.go
@@ -404,7 +404,7 @@ type TileSummaryRecord struct {
 func (i Interop) TileSummary() []TileSummaryRecord {
 	tiles := make(map[string]TileSummaryRecord)
 	for _, record := range i.TileMetrics.Records {
-		name := record.LT.TileName()
+		name := record.TileName()
 		ts, ok := tiles[name]
 		if !ok {
 			ts.LT = record.LT
@@ -435,7 +435,7 @@ func (i Interop) TileSummary() []TileSummaryRecord {
 	}
 
 	for _, record := range i.ExtendedTileMetrics.Records {
-		name := record.LT.TileName()
+		name := record.TileName()
 		ts := tiles[name]
 		ts.PercentOccupied = OptionalFloat(100 * float64(record.OccupiedClusters) / float64(tiles[name].ClusterCount))
 		tiles[name] = ts

--- a/interop/qmetrics.go
+++ b/interop/qmetrics.go
@@ -141,7 +141,7 @@ func parseQMetricRecords4(r io.Reader, qm *QMetrics) error {
 		if err != nil {
 			return err
 		}
-		record.LTC = recordV4.ltc1.normalize()
+		record.LTC = recordV4.normalize()
 		record.Histogram = make([]int, qm.Bins)
 		for i := range recordV4.Histogram {
 			record.Histogram[i] = int(recordV4.Histogram[i])
@@ -166,7 +166,7 @@ func parseQMetricRecords6(r io.Reader, qm *QMetrics) error {
 		if err != nil {
 			return err
 		}
-		record.LTC = recordV6.ltc1.normalize()
+		record.LTC = recordV6.normalize()
 		record.Histogram = make([]int, qm.Bins)
 		for i := range recordV6.Histogram {
 			record.Histogram[i] = int(recordV6.Histogram[i])
@@ -192,7 +192,7 @@ func parseQMetricRecords7(r io.Reader, qm *QMetrics) error {
 		if err != nil {
 			return err
 		}
-		record.LTC = recordV7.ltc2.normalize()
+		record.LTC = recordV7.normalize()
 		record.Histogram = make([]int, qm.Bins)
 		for i := range recordV7.Histogram {
 			record.Histogram[i] = int(recordV7.Histogram[i])
@@ -242,7 +242,7 @@ func ReadQMetrics(filename string) (QMetrics, error) {
 	if err != nil {
 		return QMetrics{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	r := bufio.NewReader(f)
 	return parseQMetrics(r)
 }

--- a/interop/runinfo.go
+++ b/interop/runinfo.go
@@ -166,7 +166,7 @@ func ReadRunInfo(filename string) (ri RunInfo, err error) {
 	if err != nil {
 		return ri, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return ParseRunInfo(f)
 }
 

--- a/interop/runparameters.go
+++ b/interop/runparameters.go
@@ -419,6 +419,6 @@ func ReadRunParameters(filename string) (RunParameters, error) {
 	if err != nil {
 		return rp, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return ParseRunParameters(f)
 }

--- a/interop/tilemetrics.go
+++ b/interop/tilemetrics.go
@@ -185,7 +185,7 @@ func parseTileMetricRecordsV2(r io.Reader, tm *TileMetrics) error {
 		key := [2]uint16{rt.Lane, rt.Tile}
 		if _, ok := tiles[key]; !ok {
 			tiles[key] = &TileRecord{
-				LT:             rt.lt1.normalize(),
+				LT:             rt.normalize(),
 				PercentAligned: make(map[int]float64),
 			}
 		}
@@ -251,7 +251,7 @@ func parseTileMetricRecordsV3(r io.Reader, tm *TileMetrics) error {
 		}
 		if _, ok := records[lane][tile]; !ok {
 			records[lane][tile] = &TileRecord{
-				LT:             t.lt2.normalize(),
+				LT:             t.normalize(),
 				PercentAligned: make(map[int]float64),
 			}
 		}
@@ -299,20 +299,20 @@ func ReadTileMetrics(filename string) (tm TileMetrics, err error) {
 	if err != nil {
 		return tm, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	r := bufio.NewReader(f)
 	tm.Header, err = parseHeader(r)
 	if err != nil {
 		return tm, nil
 	}
 
-	switch tm.Header.Version {
+	switch tm.Version {
 	case 2:
 		err = parseTileMetricsV2(r, &tm)
 	case 3:
 		err = parseTileMetricsV3(r, &tm)
 	default:
-		return tm, fmt.Errorf("unsupported tile metrics version: %d", tm.Header.Version)
+		return tm, fmt.Errorf("unsupported tile metrics version: %d", tm.Version)
 	}
 
 	return tm, err

--- a/mock/files.go
+++ b/mock/files.go
@@ -14,7 +14,7 @@ func WriteTempFile(t *testing.T, filename string, content string) (string, error
 	if err != nil {
 		return path, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := io.WriteString(f, content); err != nil {
 		return path, err
 	}

--- a/mongo/db.go
+++ b/mongo/db.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"github.com/spf13/viper"
@@ -29,6 +30,12 @@ type DB struct {
 	*mongo.Database
 }
 
+func closeCursor(c *mongo.Cursor, ctx context.Context) {
+	if err := c.Close(ctx); err != nil {
+		slog.Error("failed to close cursor", "context", ctx, "error", err)
+	}
+}
+
 func Connect() (*DB, error) {
 	mongo_db := viper.GetString("database.name")
 	mongo_host := viper.GetString("database.host")
@@ -48,7 +55,7 @@ func Connect() (*DB, error) {
 	})
 	client, err := mongo.Connect(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("mongo.Connect() failed: %s\n", err)
+		return nil, fmt.Errorf("mongo.Connect() failed: %s", err)
 	}
 
 	if err := client.Ping(ctx, nil); err != nil {

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-var ConflictError = errors.New("conflicting operation")
+var ErrConflict = errors.New("conflicting operation")
 
 type PageOutOfBoundsError struct {
 	page       int

--- a/mongo/panels.go
+++ b/mongo/panels.go
@@ -151,7 +151,7 @@ func (db DB) Panel(id string, version string) (cleve.GenePanel, error) {
 	if err != nil {
 		return p.GenePanel, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 	if ok := cursor.Next(context.TODO()); !ok {
 		return p.GenePanel, ErrNoDocuments
 	}
@@ -249,7 +249,7 @@ func (db DB) PanelCategories() ([]string, error) {
 	if err != nil {
 		return categories, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 	cursor.Next(context.TODO())
 
 	type aux struct {
@@ -272,16 +272,16 @@ func (db DB) CreatePanel(p cleve.GenePanel) error {
 		return err
 	}
 	if existingPanel.Archived {
-		return fmt.Errorf("%w: panel is archived", ConflictError)
+		return fmt.Errorf("%w: panel is archived", ErrConflict)
 	}
 	if existingPanel.Version.NewerThan(p.Version) {
-		return fmt.Errorf("%w: a newer version of this panel already exists, most recent version is %s", ConflictError, existingPanel.Version)
+		return fmt.Errorf("%w: a newer version of this panel already exists, most recent version is %s", ErrConflict, existingPanel.Version)
 	}
 	if existingPanel.Date.After(p.Date) {
-		return fmt.Errorf("%w: a version with a more recent creation date already exists", ConflictError)
+		return fmt.Errorf("%w: a version with a more recent creation date already exists", ErrConflict)
 	}
 	if time.Now().Before(p.Date) {
-		return fmt.Errorf("%w: panel cannot have a creation date in the future", ConflictError)
+		return fmt.Errorf("%w: panel cannot have a creation date in the future", ErrConflict)
 	}
 	auxPanel := struct {
 		ImportedAt      time.Time
@@ -371,7 +371,7 @@ func (db DB) PanelIndex() ([]map[string]string, error) {
 	if err != nil {
 		return []map[string]string{}, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	var indexes []map[string]string
 

--- a/mongo/platform.go
+++ b/mongo/platform.go
@@ -39,7 +39,7 @@ func (db DB) Platforms() (cleve.Platforms, error) {
 		}
 		return platforms, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	err = cursor.All(context.TODO(), &platforms.Platforms)
 	return platforms.Condense(), err

--- a/mongo/run_qc.go
+++ b/mongo/run_qc.go
@@ -119,13 +119,13 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 	if err != nil {
 		return qc, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	if !cursor.Next(context.TODO()) {
 		// No documents
-		qc.PaginationMetadata.TotalCount = 0
+		qc.TotalCount = 0
 	}
-	if err := cursor.Decode(&qc.PaginationMetadata); qc.PaginationMetadata.TotalCount > 0 && err != nil {
+	if err := cursor.Decode(&qc.PaginationMetadata); qc.TotalCount > 0 && err != nil {
 		return qc, err
 	}
 	if qc.PageSize > 0 {
@@ -164,7 +164,7 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 	if err != nil {
 		return qc, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	for cursor.Next(context.TODO()) {
 		var auxQc struct {
@@ -180,7 +180,7 @@ func (db DB) RunQCs(filter cleve.QcFilter) (cleve.QcResult, error) {
 			auxQc.Qc.Date = time.Time{}
 		}
 
-		qc.PaginationMetadata.Count++
+		qc.Count++
 		qc.InteropSummary = append(qc.InteropSummary, auxQc.Qc)
 	}
 
@@ -222,7 +222,7 @@ func (db DB) RunQCIndex() ([]map[string]string, error) {
 	if err != nil {
 		return []map[string]string{}, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	var indexes []map[string]string
 

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -238,7 +238,7 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 
 	if !cursor.Next(context.TODO()) {
 		// No runs in result
-		r.PaginationMetadata.TotalCount = 0
+		r.TotalCount = 0
 	}
 	if err := cursor.Decode(&r.PaginationMetadata); r.TotalCount > 0 && err != nil {
 		return r, err
@@ -270,7 +270,7 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 	if err != nil {
 		return r, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	for cursor.Next(context.TODO()) {
 		var run cleve.Run
@@ -408,7 +408,7 @@ func (db DB) RunIndex() ([]map[string]string, error) {
 	if err != nil {
 		return []map[string]string{}, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	var indexes []map[string]string
 

--- a/mongo/samples.go
+++ b/mongo/samples.go
@@ -123,7 +123,7 @@ func (db DB) Samples(filter *cleve.SampleFilter) (*cleve.SampleResult, error) {
 	if err != nil {
 		return &sampleResult, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 	if ok := cursor.Next(context.TODO()); ok {
 		err := cursor.Decode(&sampleResult)
 		if err != nil {

--- a/mongo/samplesheet.go
+++ b/mongo/samplesheet.go
@@ -150,7 +150,7 @@ func (db DB) SampleSheetIndex() ([]map[string]string, error) {
 	if err != nil {
 		return []map[string]string{}, err
 	}
-	defer cursor.Close(context.TODO())
+	defer closeCursor(cursor, context.TODO())
 
 	var indexes []map[string]string
 

--- a/runcompletionstatus.go
+++ b/runcompletionstatus.go
@@ -59,7 +59,7 @@ func ReadRunCompletionStatus(filename string) (RunCompletionStatus, error) {
 	if err != nil {
 		return status, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	data, err := io.ReadAll(f)
 	if err != nil {

--- a/running_summary.go
+++ b/running_summary.go
@@ -33,7 +33,7 @@ func (v *RunningSummary[T]) Push(x T, weight ...T) error {
 		}
 		w = float64(weight[0])
 		v.wSum += w
-		v.w2Sum += math.Pow(w, 2)
+		v.w2Sum += w * w
 	}
 	if v.wSum == 1 {
 		v.Mean = float64(x)

--- a/samplesheet.go
+++ b/samplesheet.go
@@ -496,7 +496,7 @@ func ReadSampleSheet(filename string) (SampleSheet, error) {
 	if err != nil {
 		return SampleSheet{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	finfo, err := os.Stat(filename)
 	if err != nil {
 		return SampleSheet{}, err


### PR DESCRIPTION
The linting has been turned off for a while due some config issues in the pre-commit hooks as well as my editor, so there were quite a few linting issues that had to be addressed.