### PR TITLE
feat: add functions for detecting run state

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,4 +11,4 @@ formatters:
     - gofumpt
     - goimports
 issues:
-  fix: true
+  fix: false

--- a/cmd/cleve/run/add.go
+++ b/cmd/cleve/run/add.go
@@ -76,7 +76,7 @@ var (
 				log.Fatal(err)
 			}
 
-			if runState == cleve.Ready {
+			if runState == cleve.StateReady {
 				log.Printf("adding qc for run %s", run.RunID)
 				if err := db.CreateRunQC(run.RunID, interopData.Summarise()); err != nil {
 					log.Fatal(err)

--- a/cmd/cleve/run/add.go
+++ b/cmd/cleve/run/add.go
@@ -68,7 +68,7 @@ var (
 				Platform:       interopData.RunInfo.Platform,
 				RunParameters:  interopData.RunParameters,
 				RunInfo:        interopData.RunInfo,
-				StateHistory:   []cleve.TimedRunState{{State: runState, Time: time.Now()}},
+				StateHistory:   cleve.StateHistory{{State: runState, Time: time.Now()}},
 				Analysis:       []*cleve.Analysis{},
 			}
 

--- a/cmd/cleve/run/add.go
+++ b/cmd/cleve/run/add.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"time"
 
 	"github.com/gmc-norr/cleve"
 	"github.com/gmc-norr/cleve/interop"
@@ -12,82 +11,76 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	runState cleve.RunState
-	addCmd   = &cobra.Command{
-		Use:   "add [flags] run_directory",
-		Short: "Add a sequencing run",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("run directory is required")
+var addCmd = &cobra.Command{
+	Use:   "add [flags] run_directory",
+	Short: "Add a sequencing run",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("run directory is required")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		db, err := mongo.Connect()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		runDir, err := filepath.Abs(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		interopData, err := interop.InteropFromDir(runDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		sampleSheetFile, err := cleve.MostRecentSamplesheet(runDir)
+		if err != nil {
+			if err.Error() == "no samplesheet found" {
+				log.Printf("no samplesheet found for run")
+			} else {
+				log.Fatal(err)
 			}
-			state, _ := cmd.Flags().GetString("state")
-			return runState.Set(state)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			db, err := mongo.Connect()
+		}
+
+		if sampleSheetFile != "" {
+			log.Printf("most recent samplesheet: %s", sampleSheetFile)
+			samplesheet, err := cleve.ReadSampleSheet(sampleSheetFile)
 			if err != nil {
 				log.Fatal(err)
 			}
-
-			runDir, err := filepath.Abs(args[0])
+			_, err = db.CreateSampleSheet(samplesheet, mongo.SampleSheetWithRunId(interopData.RunInfo.RunId))
 			if err != nil {
 				log.Fatal(err)
 			}
+		}
 
-			interopData, err := interop.InteropFromDir(runDir)
-			if err != nil {
+		run := cleve.Run{
+			RunID:          interopData.RunInfo.RunId,
+			ExperimentName: interopData.RunParameters.ExperimentName,
+			Path:           runDir,
+			Platform:       interopData.RunInfo.Platform,
+			RunParameters:  interopData.RunParameters,
+			RunInfo:        interopData.RunInfo,
+			Analysis:       []*cleve.Analysis{},
+		}
+		currentState := run.State()
+		run.StateHistory.Add(currentState)
+		log.Printf("Setting run state to %s", currentState)
+
+		if err = db.CreateRun(&run); err != nil {
+			log.Fatal(err)
+		}
+
+		if run.StateHistory.LastState().State == cleve.StateReady {
+			log.Printf("adding qc for run %s", run.RunID)
+			if err := db.CreateRunQC(run.RunID, interopData.Summarise()); err != nil {
 				log.Fatal(err)
 			}
+		}
 
-			sampleSheetFile, err := cleve.MostRecentSamplesheet(runDir)
-			if err != nil {
-				if err.Error() == "no samplesheet found" {
-					log.Printf("no samplesheet found for run")
-				} else {
-					log.Fatal(err)
-				}
-			}
-
-			if sampleSheetFile != "" {
-				log.Printf("most recent samplesheet: %s", sampleSheetFile)
-				samplesheet, err := cleve.ReadSampleSheet(sampleSheetFile)
-				if err != nil {
-					log.Fatal(err)
-				}
-				_, err = db.CreateSampleSheet(samplesheet, mongo.SampleSheetWithRunId(interopData.RunInfo.RunId))
-				if err != nil {
-					log.Fatal(err)
-				}
-			}
-
-			run := cleve.Run{
-				RunID:          interopData.RunInfo.RunId,
-				ExperimentName: interopData.RunParameters.ExperimentName,
-				Path:           runDir,
-				Platform:       interopData.RunInfo.Platform,
-				RunParameters:  interopData.RunParameters,
-				RunInfo:        interopData.RunInfo,
-				StateHistory:   cleve.StateHistory{{State: runState, Time: time.Now()}},
-				Analysis:       []*cleve.Analysis{},
-			}
-
-			if err = db.CreateRun(&run); err != nil {
-				log.Fatal(err)
-			}
-
-			if runState == cleve.StateReady {
-				log.Printf("adding qc for run %s", run.RunID)
-				if err := db.CreateRunQC(run.RunID, interopData.Summarise()); err != nil {
-					log.Fatal(err)
-				}
-			}
-
-			log.Printf("Successfully added run %s", run.RunID)
-		},
-	}
-)
-
-func init() {
-	addCmd.Flags().StringP("state", "s", "pending", "state of the run")
+		log.Printf("Successfully added run %s", run.RunID)
+	},
 }

--- a/cmd/cleve/run/update.go
+++ b/cmd/cleve/run/update.go
@@ -68,11 +68,20 @@ var (
 			reloadMetadata, _ := cmd.Flags().GetBool("reload-metadata")
 			var run *cleve.Run
 
-			if reloadQc || reloadMetadata {
-				run, err = db.Run(args[0], false)
-				if err != nil {
-					log.Fatalf("error: %s", err)
+			run, err = db.Run(args[0], false)
+			if err != nil {
+				log.Fatalf("error: %s", err)
+			}
+
+			lastState := run.StateHistory.LastState().State
+			currentState := run.State()
+
+			if lastState != currentState {
+				if err := db.SetRunState(run.RunID, currentState); err != nil {
+					log.Fatalf("error: failed to set run state: %s", err)
 				}
+				log.Printf("updated run state from %s to %s", lastState, currentState)
+				didSomething = true
 			}
 
 			if reloadQc {

--- a/cmd/cleve/run/update.go
+++ b/cmd/cleve/run/update.go
@@ -104,7 +104,7 @@ var (
 				}
 				// TODO: There should be a method on the run struct that checks the run state.
 				// Update the state by using the last known run state
-				if err := db.SetRunState(run.RunID, run.StateHistory[0].State); err != nil {
+				if err := db.SetRunState(run.RunID, run.StateHistory.LastState().State); err != nil {
 					log.Fatalf("error setting run state: %s", err)
 				}
 				didSomething = true

--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -97,7 +97,7 @@ func AddRunQcHandler(db RunQCGetterSetter) gin.HandlerFunc {
 			return
 		}
 
-		if len(run.StateHistory) == 0 || run.StateHistory[0].State != cleve.Ready {
+		if len(run.StateHistory) == 0 || run.StateHistory[0].State != cleve.StateReady {
 			ctx.AbortWithStatusJSON(
 				http.StatusNotFound,
 				gin.H{"error": fmt.Sprintf("run %s not ready", runId)},

--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -97,7 +97,7 @@ func AddRunQcHandler(db RunQCGetterSetter) gin.HandlerFunc {
 			return
 		}
 
-		if len(run.StateHistory) == 0 || run.StateHistory[0].State != cleve.StateReady {
+		if run.StateHistory.LastState().State != cleve.StateReady {
 			ctx.AbortWithStatusJSON(
 				http.StatusNotFound,
 				gin.H{"error": fmt.Sprintf("run %s not ready", runId)},

--- a/gin/runs.go
+++ b/gin/runs.go
@@ -100,7 +100,7 @@ func AddRunHandler(db RunSetter) gin.HandlerFunc {
 			Platform:       interopData.RunInfo.Platform,
 			RunParameters:  interopData.RunParameters,
 			RunInfo:        interopData.RunInfo,
-			StateHistory:   []cleve.TimedRunState{{State: state, Time: time.Now()}},
+			StateHistory:   cleve.StateHistory{{State: state, Time: time.Now()}},
 			Analysis:       []*cleve.Analysis{},
 		}
 

--- a/interop/runinfo.go
+++ b/interop/runinfo.go
@@ -24,6 +24,12 @@ var readyMarkers = map[string]string{
 	"MiSeq":          "CopyComplete.txt",
 }
 
+var completionStatus = map[string]string{
+	"NovaSeq X Plus": "RunCompletionStatus.xml",
+	"NextSeq 5x0":    "RunCompletionStatus.xml",
+	"MiSeq":          "AnalysisJobInfo.xml",
+}
+
 // Current sequencers that we use and support
 var instrumentIds = []idMatcher{
 	{idPattern: regexp.MustCompile(`^LH\d{5}$`), name: "NovaSeq X Plus"},
@@ -205,4 +211,8 @@ func IdentifyFlowcell(fcid string) string {
 func PlatformReadyMarker(platform string) string {
 	marker := readyMarkers[platform]
 	return marker
+}
+
+func PlatformCompletionStatus(platform string) string {
+	return completionStatus[platform]
 }

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -387,11 +387,11 @@ func (db DB) SetRunPath(runId string, path string) error {
 	return nil
 }
 
-func (db DB) GetRunStateHistory(runId string) ([]cleve.TimedRunState, error) {
+func (db DB) GetRunStateHistory(runId string) (cleve.StateHistory, error) {
 	opts := options.FindOne().SetProjection(bson.D{{Key: "state_history", Value: 1}})
 	res := db.RunCollection().FindOne(context.TODO(), bson.D{{Key: "run_id", Value: runId}}, opts)
 
-	var stateHistory []cleve.TimedRunState
+	var stateHistory cleve.StateHistory
 	err := res.Decode(&stateHistory)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {

--- a/run.go
+++ b/run.go
@@ -21,7 +21,7 @@ type Run struct {
 	Path             string                `bson:"path" json:"path"`
 	Platform         string                `bson:"platform" json:"platform"`
 	Created          time.Time             `bson:"created" json:"created"`
-	StateHistory     []TimedRunState       `bson:"state_history" json:"state_history"`
+	StateHistory     StateHistory          `bson:"state_history" json:"state_history"`
 	SampleSheet      *SampleSheetInfo      `bson:"samplesheet,omitempty" json:"samplesheet"`
 	SampleSheetFiles []SampleSheetInfo     `bson:"samplesheets,omitempty" json:"samplesheets"`
 	RunParameters    interop.RunParameters `bson:"run_parameters,omitzero" json:"run_parameters,omitzero"`
@@ -68,7 +68,7 @@ func unmarshalRunV1(data []byte) (r Run, err error) {
 		Path             string            `bson:"path" json:"path"`
 		Platform         string            `bson:"platform" json:"platform"`
 		Created          time.Time         `bson:"created" json:"created"`
-		StateHistory     []TimedRunState   `bson:"state_history" json:"state_history"`
+		StateHistory     StateHistory      `bson:"state_history" json:"state_history"`
 		SampleSheet      *SampleSheetInfo  `bson:"samplesheet,omitempty" json:"samplesheet"`
 		SampleSheetFiles []SampleSheetInfo `bson:"samplesheets,omitempty" json:"samplesheets"`
 		RunInfo          struct {

--- a/runcompletionstatus.go
+++ b/runcompletionstatus.go
@@ -2,54 +2,112 @@ package cleve
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"os"
 )
 
 type RunCompletionStatus struct {
-	Status  string
+	Success bool
 	Message string
 }
 
+type completionStatusNovaSeq struct {
+	RunStatus string `xml:"RunStatus"`
+	RunError  struct {
+		Type    string `xml:"Type"`
+		Message string `xml:"Message"`
+	} `xml:"RunError"`
+}
+
+func (s completionStatusNovaSeq) toStatus() RunCompletionStatus {
+	msg := s.RunStatus
+	if s.RunError.Type != "" {
+		msg += ": " + s.RunError.Type
+	}
+	if s.RunError.Message != "" {
+		msg += ": " + s.RunError.Message
+	}
+	return RunCompletionStatus{
+		Success: s.RunStatus == "RunCompleted",
+		Message: msg,
+	}
+}
+
+func (s completionStatusNovaSeq) valid() bool {
+	return s.RunStatus != ""
+}
+
+type completionStatusNextSeq struct {
+	CompletionStatus string `xml:"CompletionStatus"`
+	ErrorDescription string `xml:"ErrorDescription"`
+}
+
+func (s completionStatusNextSeq) toStatus() RunCompletionStatus {
+	msg := s.CompletionStatus
+	if s.ErrorDescription != "" && s.ErrorDescription != "None" {
+		msg += ": " + s.ErrorDescription
+	}
+	return RunCompletionStatus{
+		Success: s.CompletionStatus == "CompletedAsPlanned",
+		Message: msg,
+	}
+}
+
+func (s completionStatusNextSeq) valid() bool {
+	return s.CompletionStatus != ""
+}
+
+type completionStatusMiSeq struct {
+	XMLName xml.Name
+	Error   string `xml:"Error"`
+	Warning string `xml:"Warning"`
+}
+
+func (s completionStatusMiSeq) toStatus() RunCompletionStatus {
+	success := s.Error == "" && s.Warning == ""
+	var msg string
+	if success {
+		msg = "Success"
+	} else {
+		if s.Error != "" {
+			msg = "Error: " + s.Error
+			if s.Warning != "" {
+				msg += ", "
+			}
+		}
+		if s.Warning != "" {
+			msg += "Warning: " + s.Warning
+		}
+	}
+	return RunCompletionStatus{
+		Success: success,
+		Message: msg,
+	}
+}
+
+func (s completionStatusMiSeq) valid() bool {
+	return s.XMLName.Local == "AnalysisJobInfo"
+}
+
 func ParseRunCompletionStatus(data []byte) (RunCompletionStatus, error) {
-	type xmlData struct {
-		CompletionStatus string `xml:"CompletionStatus"`
-		RunStatus        string `xml:"RunStatus"`
-		ErrorDescription string `xml:"ErrorDescription"`
-	}
-	var status RunCompletionStatus
-	var d xmlData
-
-	if err := xml.Unmarshal(data, &d); err != nil {
-		return status, err
+	var err error
+	var novaseqStatus completionStatusNovaSeq
+	if err = xml.Unmarshal(data, &novaseqStatus); novaseqStatus.valid() && err == nil {
+		return novaseqStatus.toStatus(), nil
 	}
 
-	if d.CompletionStatus != "" {
-		switch d.CompletionStatus {
-		case "CompletedAsPlanned":
-			status.Status = "success"
-			status.Message = d.CompletionStatus
-		default:
-			status.Status = "error"
-		}
+	var nextseqStatus completionStatusNextSeq
+	if err = xml.Unmarshal(data, &nextseqStatus); nextseqStatus.valid() && err == nil {
+		return nextseqStatus.toStatus(), nil
 	}
 
-	if d.RunStatus != "" {
-		switch d.RunStatus {
-		case "RunCompleted":
-			status.Status = "success"
-			status.Message = d.RunStatus
-		default:
-			status.Status = "error"
-			status.Message = d.RunStatus
-		}
+	var miseqStatus completionStatusMiSeq
+	if err = xml.Unmarshal(data, &miseqStatus); miseqStatus.valid() && err == nil {
+		return miseqStatus.toStatus(), nil
 	}
 
-	if d.ErrorDescription != "" && d.ErrorDescription != "None" {
-		status.Message = d.ErrorDescription
-	}
-
-	return status, nil
+	return RunCompletionStatus{}, fmt.Errorf("failed to parse completion status")
 }
 
 func ReadRunCompletionStatus(filename string) (RunCompletionStatus, error) {

--- a/runcompletionstatus_test.go
+++ b/runcompletionstatus_test.go
@@ -1,55 +1,95 @@
 package cleve
 
 import (
-	"errors"
-	"os"
 	"testing"
 )
 
-func TestReadRunCompletionStatus(t *testing.T) {
+func TestParseRunCompletionStatus(t *testing.T) {
 	cases := []struct {
-		name     string
-		filename string
-		status   string
-		message  string
+		name    string
+		xml     []byte
+		error   bool
+		success bool
+		message string
 	}{
 		{
-			"novaseq",
-			"/home/nima18/git/cleve/test_data/novaseq_full/RunCompletionStatus.xml",
-			"success",
-			"RunCompleted",
+			name:    "novaseq success",
+			xml:     []byte(`<?xml version="1.0" encoding="utf-8"?><RunCompletionStatus><RunStatus>RunCompleted</RunStatus></RunCompletionStatus>`),
+			success: true,
+			message: "RunCompleted",
 		},
 		{
-			"nextseq1",
-			"/home/nima18/git/cleve/test_data/nextseq1_full/RunCompletionStatus.xml",
-			"success",
-			"CompletedAsPlanned",
+			name: "novaseq error",
+			xml: []byte(`<?xml version="1.0" encoding="utf-8"?>
+				<RunCompletionStatus>
+					<RunStatus>RunErrored</RunStatus>
+					<RunError>
+						<Type>Illumina.Instrument.Recipe.Runtime.Exceptions.RecipeExecutionFailedException</Type>
+						<Message>I/O data integrity check failed</Message>
+					</RunError>
+				</RunCompletionStatus>`),
+			success: false,
+			message: "RunErrored: Illumina.Instrument.Recipe.Runtime.Exceptions.RecipeExecutionFailedException: I/O data integrity check failed",
 		},
 		{
-			"nextseq2",
-			"/home/nima18/git/cleve/test_data/nextseq2_full/RunCompletionStatus.xml",
-			"success",
-			"CompletedAsPlanned",
+			name: "nextseq success",
+			xml: []byte(`<?xml version="1.0"?>
+				<RunCompletionStatus>
+					<CompletionStatus>CompletedAsPlanned</CompletionStatus>
+					<ErrorDescription>None</ErrorDescription>
+				</RunCompletionStatus>`),
+			success: true,
+			message: "CompletedAsPlanned",
 		},
 		{
-			"nextseq_failed",
-			"/home/nima18/git/cleve/test_data/230713_NB551119_0374_AHMVKTBGXT/RunCompletionStatus.xml",
-			"error",
-			"Thread was being aborted. (System.Threading.ThreadAbortException)",
+			name: "nextseq error",
+			xml: []byte(`<?xml version="1.0"?>
+				<RunCompletionStatus>
+					<CompletionStatus>UserEndedEarly</CompletionStatus>
+					<ErrorDescription>Thread was aborted</ErrorDescription>
+				</RunCompletionStatus>`),
+			success: false,
+			message: "UserEndedEarly: Thread was aborted",
+		},
+		{
+			name:    "miseq success",
+			xml:     []byte(`<?xml version="1.0"?><AnalysisJobInfo></AnalysisJobInfo>`),
+			success: true,
+			message: "Success",
+		},
+		{
+			name:    "miseq error",
+			xml:     []byte(`<?xml version="1.0"?><AnalysisJobInfo><Error>Sequencing failed</Error></AnalysisJobInfo>`),
+			success: false,
+			message: "Error: Sequencing failed",
+		},
+		{
+			name:    "miseq warning",
+			xml:     []byte(`<?xml version="1.0"?><AnalysisJobInfo><Warning>Stuff went wrong</Warning></AnalysisJobInfo>`),
+			success: false,
+			message: "Warning: Stuff went wrong",
+		},
+		{
+			name:    "miseq error and warning",
+			xml:     []byte(`<?xml version="1.0"?><AnalysisJobInfo><Error>Sequencing failed</Error><Warning>Stuff went wrong</Warning></AnalysisJobInfo>`),
+			success: false,
+			message: "Error: Sequencing failed, Warning: Stuff went wrong",
+		},
+		{
+			name:  "invalid document",
+			xml:   []byte(`<?xml version="1.0"?><OtherCompletionStatus><Error>Sequencing failed</Error><Warning>Stuff went wrong</Warning></OtherCompletionStatus>`),
+			error: true,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if _, err := os.Stat(c.filename); errors.Is(err, os.ErrNotExist) {
-				t.Skip("test data not found, skipping")
-			}
-			rct, err := ReadRunCompletionStatus(c.filename)
-			if err != nil {
+			rct, err := ParseRunCompletionStatus(c.xml)
+			if c.error != (err != nil) {
 				t.Fatal(err.Error())
 			}
-			if c.status != rct.Status {
-				t.Errorf(`expected status "%s", got "%s"`, c.status, rct.Status)
+			if c.success != rct.Success {
+				t.Errorf(`expected success to be %t, got %t`, c.success, rct.Success)
 			}
 			if c.message != rct.Message {
 				t.Errorf(`expected message "%s", got "%s"`, c.message, rct.Message)

--- a/runstate.go
+++ b/runstate.go
@@ -3,6 +3,7 @@ package cleve
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -100,4 +101,22 @@ func (r *RunState) UnmarshalJSON(data []byte) error {
 type TimedRunState struct {
 	State RunState  `bson:"state" json:"state"`
 	Time  time.Time `bson:"time" json:"time"`
+}
+
+// StateHistory represents a slice of TimedRunState
+type StateHistory []TimedRunState
+
+// LastState returns the most recent TimedRunState in the state history. If the
+// history is empty, Unknown is returned with the current time.
+func (h StateHistory) LastState() TimedRunState {
+	if len(h) == 0 {
+		return TimedRunState{
+			Time:  time.Now(),
+			State: StateUnknown,
+		}
+	}
+	slices.SortFunc(h, func(a, b TimedRunState) int {
+		return b.Time.Compare(a.Time)
+	})
+	return h[0]
 }

--- a/runstate.go
+++ b/runstate.go
@@ -120,3 +120,12 @@ func (h StateHistory) LastState() TimedRunState {
 	})
 	return h[0]
 }
+
+// Add adds a new state to the state history with the current time.
+func (h *StateHistory) Add(state RunState) {
+	s := TimedRunState{
+		Time:  time.Now(),
+		State: state,
+	}
+	*h = append(*h, s)
+}

--- a/runstate.go
+++ b/runstate.go
@@ -12,27 +12,27 @@ import (
 type RunState int
 
 const (
-	New RunState = iota
-	Ready
-	Pending
-	Complete
-	Incomplete
-	Error
-	Moved
-	Moving
-	Unknown
+	StateNew RunState = iota
+	StateReady
+	StatePending
+	StateComplete
+	StateIncomplete
+	StateError
+	StateMoved
+	StateMoving
+	StateUnknown
 )
 
 var ValidRunStates = map[string]RunState{
-	"new":        New,
-	"ready":      Ready,
-	"pending":    Pending,
-	"complete":   Complete,
-	"incomplete": Incomplete,
-	"error":      Error,
-	"moved":      Moved,
-	"moving":     Moving,
-	"unknown":    Unknown,
+	"new":        StateNew,
+	"ready":      StateReady,
+	"pending":    StatePending,
+	"complete":   StateComplete,
+	"incomplete": StateIncomplete,
+	"error":      StateError,
+	"moved":      StateMoved,
+	"moving":     StateMoving,
+	"unknown":    StateUnknown,
 }
 
 func (s RunState) String() string {

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -13,27 +13,27 @@ func TestRunState(t *testing.T) {
 	tests := []testCase{
 		{
 			name: "new",
-			args: New,
+			args: StateNew,
 			want: "new",
 		},
 		{
 			name: "ready",
-			args: Ready,
+			args: StateReady,
 			want: "ready",
 		},
 		{
 			name: "pending",
-			args: Pending,
+			args: StatePending,
 			want: "pending",
 		},
 		{
 			name: "complete",
-			args: Complete,
+			args: StateComplete,
 			want: "complete",
 		},
 		{
 			name: "error",
-			args: Error,
+			args: StateError,
 			want: "error",
 		},
 	}

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -2,6 +2,7 @@ package cleve
 
 import (
 	"testing"
+	"time"
 )
 
 func TestRunState(t *testing.T) {
@@ -67,5 +68,65 @@ func TestRunStateSet(t *testing.T) {
 	expected := "new"
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestLastState(t *testing.T) {
+	testcases := []struct {
+		name      string
+		history   StateHistory
+		lastState RunState
+	}{
+		{
+			name:      "empty history",
+			history:   StateHistory{},
+			lastState: StateUnknown,
+		},
+		{
+			name: "single state",
+			history: StateHistory{
+				{
+					Time:  time.Now(),
+					State: StateReady,
+				},
+			},
+			lastState: StateReady,
+		},
+		{
+			name: "multiple states",
+			history: StateHistory{
+				{
+					Time:  time.Now(),
+					State: StateReady,
+				},
+				{
+					Time:  time.Now().Add(-time.Hour),
+					State: StatePending,
+				},
+			},
+			lastState: StateReady,
+		},
+		{
+			name: "multiple states reversed",
+			history: StateHistory{
+				{
+					Time:  time.Now().Add(-time.Hour),
+					State: StatePending,
+				},
+				{
+					Time:  time.Now(),
+					State: StateReady,
+				},
+			},
+			lastState: StateReady,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.history.LastState().State != c.lastState {
+				t.Errorf("expected last state to be %s, got %s", c.lastState, c.history.LastState())
+			}
+		})
 	}
 }

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -6,7 +6,7 @@
 
 {{ define "run" }}
 {{ template "header" . }}
-{{ $state := (index .run.StateHistory 0).State.String }}
+{{ $state := .run.StateHistory.LastState.State.String }}
 <header class="m-6">
     <h2 class="text-3xl">Sequencing run: {{ .run.RunID }}
         <span class="state-{{ $state }} inline-block py-1 px-2 rounded-md">

--- a/templates/run_table.tmpl
+++ b/templates/run_table.tmpl
@@ -65,8 +65,8 @@
                     <td>{{ .Platform }}</td>
                     <td>{{ .RunInfo.FlowcellName }}</td>
                     <td>{{ .RunInfo.Date.Local.Format "2006-01-02" }}</td>
-                    <td>{{ (index .StateHistory 0).State.String | title }}</td>
-                    <td>{{ (index .StateHistory 0).Time.Local.Format "2006-01-02 15:04:05 MST" }}</td>
+                    <td>{{ .StateHistory.LastState.State.String | title }}</td>
+                    <td>{{ .StateHistory.LastState.Time.Local.Format "2006-01-02 15:04:05 MST" }}</td>
                     <td><code>{{ .Path }}</code></td>
                 </tr>
                 {{ end }}


### PR DESCRIPTION
This PR adds functionality for detecting the state of runs directly in Cleve instead of relying on this to come in from the outside. In working on this I also found that the state management was a bit wonky, so I added some convenient functionality to the StateHistory field of the Run struct to make it more ergonomic to get the most recent state of a run, and to add new states to the history.

The only thing that has changed from an interface point of view is that the state argument for `run add` on the CLI has been removed. The state is now detected as a part of adding the run.

This is all part of #67, but it's not quite a wrap just yet. More PRs to come.