### PR TITLE
feat: check run state in the background

### DIFF
--- a/cmd/cleve/main.go
+++ b/cmd/cleve/main.go
@@ -49,6 +49,8 @@ func initConfig() {
 		viper.AddConfigPath(".")
 	}
 
+	viper.SetDefault("run_poll_interval", 30)
+
 	err := viper.ReadInConfig()
 	if err != nil {
 		log.Fatalf("error: %s", err)

--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -3,10 +3,16 @@ package main
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gmc-norr/cleve/gin"
 	"github.com/gmc-norr/cleve/mongo"
+	"github.com/gmc-norr/cleve/watcher"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,9 +33,34 @@ var (
 			host := viper.GetString("host")
 			port := viper.GetInt("port")
 			addr := fmt.Sprintf("%s:%d", host, port)
+
+			loglevel := slog.LevelWarn
+			if debug {
+				loglevel = slog.LevelDebug
+			}
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: loglevel}))
+			slog.SetDefault(logger)
+
+			runWatcher := watcher.NewRunWatcher(10*time.Second, db, logger)
+			defer runWatcher.Stop()
+			runWatcher.Start()
+
+			interrupt := make(chan os.Signal, 1)
+			signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				s := <-interrupt
+				slog.Error("signal received, shutting down", "signal", s)
+				runWatcher.Stop()
+				os.Exit(1)
+			}()
+
 			router := gin.NewRouter(db, debug)
-			log.Printf("Serving on %s", addr)
-			log.Fatal(http.ListenAndServe(addr, router))
+			logger.Info("serving cleve", "address", addr)
+			err = http.ListenAndServe(addr, router)
+			if err != nil {
+				slog.Error("server crashed", "error", err)
+				os.Exit(1)
+			}
 		},
 	}
 )

--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -70,13 +70,7 @@ func init() {
 	serveCmd.Flags().StringVar(&host, "host", "localhost", "host")
 	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "port")
 	serveCmd.Flags().StringVar(&logfile, "logfile", "", "file to write logs in")
-	if err := viper.BindPFlag("host", serveCmd.Flags().Lookup("host")); err != nil {
-		log.Fatal(err)
-	}
-	if err := viper.BindPFlag("port", serveCmd.Flags().Lookup("port")); err != nil {
-		log.Fatal(err)
-	}
-	if err := viper.BindPFlag("logfile", serveCmd.Flags().Lookup("logfile")); err != nil {
-		log.Fatal(err)
-	}
+	_ = viper.BindPFlag("host", serveCmd.Flags().Lookup("host"))
+	_ = viper.BindPFlag("port", serveCmd.Flags().Lookup("port"))
+	_ = viper.BindPFlag("logfile", serveCmd.Flags().Lookup("logfile"))
 }

--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -28,7 +27,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			db, err := mongo.Connect()
 			if err != nil {
-				log.Fatal(err.Error())
+				slog.Error("failed to connect to database", "error", err)
+				os.Exit(1)
 			}
 			host := viper.GetString("host")
 			port := viper.GetInt("port")

--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -41,7 +41,8 @@ var (
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: loglevel}))
 			slog.SetDefault(logger)
 
-			runWatcher := watcher.NewRunWatcher(10*time.Second, db, logger)
+			pollInterval, _ := cmd.Flags().GetInt("poll-interval")
+			runWatcher := watcher.NewRunWatcher(time.Duration(pollInterval)*time.Second, db, logger)
 			defer runWatcher.Stop()
 			runWatcher.Start()
 
@@ -70,7 +71,9 @@ func init() {
 	serveCmd.Flags().StringVar(&host, "host", "localhost", "host")
 	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "port")
 	serveCmd.Flags().StringVar(&logfile, "logfile", "", "file to write logs in")
+	serveCmd.Flags().Int("poll-interval", 30, "how often, in seconds, that state changes to runs should be checked")
 	_ = viper.BindPFlag("host", serveCmd.Flags().Lookup("host"))
 	_ = viper.BindPFlag("port", serveCmd.Flags().Lookup("port"))
 	_ = viper.BindPFlag("logfile", serveCmd.Flags().Lookup("logfile"))
+	_ = viper.BindPFlag("run_polling_interval", serveCmd.Flags().Lookup("poll-interval"))
 }

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,11 @@ database:
 # If not set, logs will only be written to stdout
 logfile: cleve.log
 
+# How often, in seconds, that Cleve should poll runs in the database
+# for state changes. Setting this too low could potentially have big
+# impact on I/O. The default is 30 seconds.
+run_polling_interval: 30
+
 # Path to a yaml file containing the api specification
 apidoc: cleve_api.yaml
 

--- a/mock/runs.go
+++ b/mock/runs.go
@@ -60,3 +60,21 @@ func (s *RunSetter) SetRunPath(runId string, path string) error {
 	s.SetRunPathInvoked = true
 	return s.SetRunPathFn(runId, path)
 }
+
+// Mock implementing the runHandler for RunWatcher
+type RunHandler struct {
+	RunsFn             func(cleve.RunFilter) (cleve.RunResult, error)
+	RunsInvoked        bool
+	SetRunStateFn      func(string, cleve.RunState) error
+	SetRunStateInvoked bool
+}
+
+func (h *RunHandler) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
+	h.RunsInvoked = true
+	return h.RunsFn(filter)
+}
+
+func (h *RunHandler) SetRunState(runId string, state cleve.RunState) error {
+	h.SetRunStateInvoked = true
+	return h.SetRunStateFn(runId, state)
+}

--- a/run.go
+++ b/run.go
@@ -36,9 +36,14 @@ type Run struct {
 
 // State detects the current state of the sequencing run.
 func (r *Run) State() RunState {
-	status, err := ReadRunCompletionStatus(filepath.Join(r.Path, interop.PlatformCompletionStatus(r.Platform)))
+	if _, err := os.Stat(r.Path); os.IsNotExist(err) {
+		return StateMoved
+	}
+	completionFile := filepath.Join(r.Path, interop.PlatformCompletionStatus(r.Platform))
+	slog.Debug("run completion status", "path", completionFile)
+	status, err := ReadRunCompletionStatus(completionFile)
 	if err != nil {
-		slog.Warn("failed to read run completion status", "run", r.RunID, "error", err)
+		slog.Debug("failed to read run completion status", "run", r.RunID, "error", err)
 		return r.state(nil)
 	}
 	return r.state(&status)

--- a/run.go
+++ b/run.go
@@ -1,7 +1,6 @@
 package cleve
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -56,15 +55,9 @@ func (r *Run) state(status *RunCompletionStatus) RunState {
 		return currentState.State
 	}
 	readyMarker := filepath.Join(r.Path, interop.PlatformReadyMarker(r.Platform))
-	slog.Info("ready marker", "path", readyMarker)
-	if info, err := os.Stat(readyMarker); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// Data is still being copied
-			return StatePending
-		}
-	} else if info.IsDir() {
-		// This should never happen
-		return StateError
+	slog.Debug("ready marker", "path", readyMarker)
+	if _, err := os.Stat(readyMarker); os.IsNotExist(err) {
+		return StatePending
 	}
 
 	if status != nil && !status.Success {

--- a/watcher/run_watcher.go
+++ b/watcher/run_watcher.go
@@ -24,7 +24,7 @@ type RunWatcher struct {
 	done chan struct{}
 }
 
-// NewRunWatcher creates a new RunWatcher. Having a poll interval less than 10 seconds is not recommended (just pulled this number out of my ass).
+// NewRunWatcher creates a new RunWatcher.
 func NewRunWatcher(pollInterval time.Duration, db runHandler, logger *slog.Logger) RunWatcher {
 	filter := cleve.NewRunFilter()
 	filter.PageSize = 30

--- a/watcher/run_watcher.go
+++ b/watcher/run_watcher.go
@@ -1,0 +1,106 @@
+package watcher
+
+import (
+	"log/slog"
+	"slices"
+	"time"
+
+	"github.com/gmc-norr/cleve"
+)
+
+type runHandler interface {
+	Runs(filter cleve.RunFilter) (cleve.RunResult, error)
+	SetRunState(runId string, state cleve.RunState) error
+}
+
+type RunWatcher struct {
+	PollInterval time.Duration
+
+	store     runHandler
+	runFilter cleve.RunFilter
+	logger    *slog.Logger
+
+	quit chan struct{}
+	done chan struct{}
+}
+
+// NewRunWatcher creates a new RunWatcher. Having a poll interval less than 10 seconds is not recommended (just pulled this number out of my ass).
+func NewRunWatcher(pollInterval time.Duration, db runHandler, logger *slog.Logger) RunWatcher {
+	filter := cleve.NewRunFilter()
+	filter.PageSize = 30
+	return RunWatcher{
+		PollInterval: pollInterval,
+		store:        db,
+		runFilter:    filter,
+		logger:       logger,
+		quit:         make(chan struct{}),
+		done:         make(chan struct{}),
+	}
+}
+
+func (w *RunWatcher) Start() {
+	w.logger.Info("starting run watcher", "poll_interval", w.PollInterval)
+	go w.start()
+}
+
+func (w *RunWatcher) start() {
+	defer close(w.done)
+
+	ticker := time.NewTicker(w.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			w.poll()
+		case <-w.quit:
+			return
+		}
+	}
+}
+
+func (w *RunWatcher) Stop() {
+	w.logger.Info("stopping run watcher, waiting for current poll (if any) finishes")
+	close(w.quit)
+	<-w.done
+	w.logger.Info("run watcher stopped")
+}
+
+func (w *RunWatcher) poll() {
+	w.updateStates()
+}
+
+func (w *RunWatcher) updateStates() {
+	w.logger.Info("checking run states")
+	w.runFilter.Page = 1
+	for {
+		w.logger.Debug("fetching runs", "page", w.runFilter.Page)
+		runs, err := w.store.Runs(w.runFilter)
+		if err != nil {
+			w.logger.Error("failed to get runs", "error", err)
+		}
+		w.logger.Debug("got runs", "page", w.runFilter.Page, "pagination", runs.PaginationMetadata)
+		if runs.Count == 0 {
+			w.logger.Debug("no more runs, bail out")
+			break
+		}
+		for _, r := range runs.Runs {
+			knownState := r.StateHistory.LastState().State
+			if slices.Contains([]cleve.RunState{cleve.StateMoving, cleve.StateMoved}, knownState) {
+				// Nothing to do if the run is being moved, and we need an external
+				// signal to update a moved case.
+				continue
+			}
+			currentState := r.State()
+			if knownState != currentState {
+				if err := w.store.SetRunState(r.RunID, currentState); err != nil {
+					w.logger.Error("failed to set run state", "run", r.RunID, "previous_state", knownState, "new_state", currentState)
+				}
+			}
+		}
+		if runs.TotalPages == w.runFilter.Page {
+			break
+		}
+		w.runFilter.Page += 1
+	}
+}

--- a/watcher/run_watcher_test.go
+++ b/watcher/run_watcher_test.go
@@ -1,0 +1,47 @@
+package watcher
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gmc-norr/cleve"
+	"github.com/gmc-norr/cleve/mock"
+)
+
+func TestRunWatcher(t *testing.T) {
+	testcases := []struct {
+		name   string
+		dbRuns cleve.RunResult
+	}{
+		{
+			name: "no runs",
+			dbRuns: cleve.RunResult{
+				PaginationMetadata: cleve.PaginationMetadata{
+					Count: 0,
+				},
+			},
+		},
+	}
+	db := mock.RunHandler{}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			db.RunsFn = func(filter cleve.RunFilter) (cleve.RunResult, error) {
+				c.dbRuns.Page = filter.Page
+				c.dbRuns.PageSize = filter.PageSize
+				return c.dbRuns, nil
+			}
+			db.SetRunStateFn = func(runId string, state cleve.RunState) error {
+				t.Logf("changing state to %s for %s", state, runId)
+				return nil
+			}
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			w := NewRunWatcher(5*time.Second, &db, logger)
+			w.Start()
+			defer w.Stop()
+			w.poll()
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a run watcher that can be used to update the state of runs in the background by comparing the current state withe the most recent state in the database. The watcher is activated when starting the web server, and the polling interval is possible to control either from the command line or with the config.