### PR TITLE
feat: ability to update run metadata from API

### DIFF
--- a/cleve_api.yaml
+++ b/cleve_api.yaml
@@ -134,11 +134,16 @@ endpoints:
         required: true
       - key: path
         type: string
-        description: new path of the run directory
+        description: new absolute path of the run directory
         required: false
       - key: state
         type: string
         description: new state of the run directory
+        required: false
+      - key: update_metadata
+        type: bool
+        description: update the metadata from RunInfo.xml and RunParameters.xml
+        default: false
         required: false
 
   - path: /runs/{run_id}/analysis

--- a/gin/runs.go
+++ b/gin/runs.go
@@ -159,6 +159,11 @@ func UpdateRunHandler(db *mongo.DB) gin.HandlerFunc {
 		}
 
 		if updateRequest.Path != "" {
+			if !filepath.IsAbs(updateRequest.Path) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "run path must be absolute"})
+				return
+			}
+
 			runinfo, err := interop.ReadRunInfo(filepath.Join(updateRequest.Path, "RunInfo.xml"))
 			if err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "when": "reading RunInfo.xml"})

--- a/gin/runs.go
+++ b/gin/runs.go
@@ -225,7 +225,7 @@ func UpdateRunHandler(db *mongo.DB) gin.HandlerFunc {
 		}
 
 		// Only update the metadata if the run has not been moved or is being moved
-		if updateRequest.UpdateMetadata && slices.Contains([]cleve.RunState{cleve.StateMoving, cleve.StateMoved}, run.StateHistory.LastState().State) {
+		if updateRequest.UpdateMetadata && !slices.Contains([]cleve.RunState{cleve.StateMoving, cleve.StateMoved}, run.StateHistory.LastState().State) {
 			runInfo, err := interop.ReadRunInfo(filepath.Join(run.Path, "RunInfo.xml"))
 			if err != nil {
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": "failed to read run info", "run": run.RunID, "error": err})

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -384,7 +384,7 @@ func (db DB) SetRunPath(runId string, path string) error {
 		return mongo.ErrNoDocuments
 	}
 
-	return nil
+	return err
 }
 
 func (db DB) GetRunStateHistory(runId string) (cleve.StateHistory, error) {


### PR DESCRIPTION
This PR adds the ability to update run metadata from RunInfo.xml and RunParameters.xml from the `PATCH /api/runs/{run_id}` endpoint. It adds a new (optional) boolean parameter to the payload: `update_metadata`. The default is false. If the run is in a `moving` or `moved` state, this update is ignored.

In addition it now also checks that the run path in the payload is absolute and returns a HTTP 400 if that is not the case.