### PR TITLE
feat: ability to update run QC from API

### DIFF
--- a/cleve_api.yaml
+++ b/cleve_api.yaml
@@ -145,6 +145,11 @@ endpoints:
         description: update the metadata from RunInfo.xml and RunParameters.xml
         default: false
         required: false
+      - key: update_qc
+        type: bool
+        description: update the qc data for a run
+        default: false
+        required: false
 
   - path: /runs/{run_id}/analysis
     method: GET

--- a/cmd/cleve/run/update.go
+++ b/cmd/cleve/run/update.go
@@ -96,7 +96,7 @@ var (
 				}
 			}
 
-			if updateQc {
+			if updateQc && run.StateHistory.LastState().State == cleve.StateReady {
 				slog.Info("updating run qc data", "run", args[0])
 				qc, err := interop.InteropFromDir(run.Path)
 				if err != nil {
@@ -108,6 +108,8 @@ var (
 					os.Exit(1)
 				}
 				didSomething = true
+			} else if updateQc {
+				slog.Warn("run is not ready, qc data will not be updated")
 			}
 
 			if updateMetadata && !run.StateHistory.LastState().State.IsMoved() {

--- a/cmd/cleve/run/update.go
+++ b/cmd/cleve/run/update.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/gmc-norr/cleve"
@@ -111,7 +110,7 @@ var (
 				didSomething = true
 			}
 
-			if updateMetadata && !slices.Contains([]cleve.RunState{cleve.StateMoving, cleve.StateMoved}, run.StateHistory.LastState().State) {
+			if updateMetadata && !run.StateHistory.LastState().State.IsMoved() {
 				slog.Info("updating run metadata", "run", args[0])
 				runInfo, err := interop.ReadRunInfo(filepath.Join(run.Path, "RunInfo.xml"))
 				if err != nil {

--- a/gin/runs.go
+++ b/gin/runs.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -225,7 +224,7 @@ func UpdateRunHandler(db *mongo.DB) gin.HandlerFunc {
 		}
 
 		// Only update the metadata if the run has not been moved or is being moved
-		if updateRequest.UpdateMetadata && !slices.Contains([]cleve.RunState{cleve.StateMoving, cleve.StateMoved}, run.StateHistory.LastState().State) {
+		if updateRequest.UpdateMetadata && !run.StateHistory.LastState().State.IsMoved() {
 			runInfo, err := interop.ReadRunInfo(filepath.Join(run.Path, "RunInfo.xml"))
 			if err != nil {
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": "failed to read run info", "run": run.RunID, "error": err})

--- a/runstate.go
+++ b/runstate.go
@@ -36,6 +36,12 @@ var ValidRunStates = map[string]RunState{
 	"unknown":    StateUnknown,
 }
 
+// IsMoved returns true if the state is `moved` or `moving`. Otherwise
+// it returns false.
+func (s RunState) IsMoved() bool {
+	return slices.Contains([]RunState{StateMoved, StateMoving}, s)
+}
+
 func (s RunState) String() string {
 	for k, v := range ValidRunStates {
 		if v == s {

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -130,3 +130,40 @@ func TestLastState(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMoved(t *testing.T) {
+	testcases := []struct {
+		name    string
+		state   RunState
+		isMoved bool
+	}{
+		{
+			name:    "moved",
+			state:   StateMoved,
+			isMoved: true,
+		},
+		{
+			name:    "moving",
+			state:   StateMoving,
+			isMoved: true,
+		},
+		{
+			name:    "ready",
+			state:   StateReady,
+			isMoved: false,
+		},
+		{
+			name:    "unknown",
+			state:   StateUnknown,
+			isMoved: false,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.state.IsMoved() != c.isMoved {
+				t.Errorf("expected IsMoved to be %t, got %t", c.isMoved, c.state.IsMoved())
+			}
+		})
+	}
+}

--- a/watcher/run_watcher.go
+++ b/watcher/run_watcher.go
@@ -2,7 +2,6 @@ package watcher
 
 import (
 	"log/slog"
-	"slices"
 	"time"
 
 	"github.com/gmc-norr/cleve"
@@ -86,7 +85,7 @@ func (w *RunWatcher) updateStates() {
 		}
 		for _, r := range runs.Runs {
 			knownState := r.StateHistory.LastState().State
-			if slices.Contains([]cleve.RunState{cleve.StateMoving, cleve.StateMoved}, knownState) {
+			if knownState.IsMoved() {
 				// Nothing to do if the run is being moved, and we need an external
 				// signal to update a moved case.
 				continue


### PR DESCRIPTION
This PR adds similar functionality as in the CLI where the QC data for a run can be updated. This is a part of the `PATCH /api/runs/{run_id}` endpoint, now with a new payload parameter `update_qc`. If the state of the run is not ready, the update will be ignored.

I found that the equivalent CLI command did not check if the run was ready before updating the QC, so this check was added, as well as a warning message if the run isn't ready and a QC update is requested.

To make things a bit more clean, a helper method for checking if a state is either `moving` or `moved` was added to cleve.RunState.

Closes #83.