### PR TITLE
fix: update state handling in templates

### DIFF
--- a/state.go
+++ b/state.go
@@ -112,16 +112,27 @@ type TimedRunState struct {
 // StateHistory represents a slice of TimedRunState
 type StateHistory []TimedRunState
 
-// LastState returns the most recent State in the state history. If the
-// history is empty, Unknown is returned.
-func (h StateHistory) LastState() State {
+// LastEntry returns the most recent TimedRunState in the state history.
+func (h StateHistory) LastEntry() TimedRunState {
 	if len(h) == 0 {
-		return StateUnknown
+		return TimedRunState{State: StateUnknown}
 	}
 	slices.SortFunc(h, func(a, b TimedRunState) int {
 		return b.Time.Compare(a.Time)
 	})
-	return h[0].State
+	return h[0]
+}
+
+// LastState returns the most recent State in the state history. If the
+// history is empty, Unknown is returned.
+func (h StateHistory) LastState() State {
+	return h.LastEntry().State
+}
+
+// LastModification returns the time of the last modification of the state.
+// If the history is empty, the zero value of time.Time will be returned.
+func (h StateHistory) LastModification() time.Time {
+	return h.LastEntry().Time
 }
 
 // Add adds a new state to the state history with the current time.

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -6,7 +6,7 @@
 
 {{ define "run" }}
 {{ template "header" . }}
-{{ $state := .run.StateHistory.LastState.State.String }}
+{{ $state := .run.StateHistory.LastState.String }}
 <header class="m-6">
     <h2 class="text-3xl">Sequencing run: {{ .run.RunID }}
         <span class="state-{{ $state }} inline-block py-1 px-2 rounded-md">

--- a/templates/run_table.tmpl
+++ b/templates/run_table.tmpl
@@ -61,12 +61,13 @@
                 {{ end }}
                 {{ range .runs }}
                 <tr class="hover:bg-accent-100">
+                    {{ $state := .StateHistory.LastEntry }}
                     <td><a class="text-accent-900" href="/runs/{{ .RunID }}">{{ .RunID }}</a></td>
                     <td>{{ .Platform }}</td>
                     <td>{{ .RunInfo.FlowcellName }}</td>
                     <td>{{ .RunInfo.Date.Local.Format "2006-01-02" }}</td>
-                    <td>{{ .StateHistory.LastState.State.String | title }}</td>
-                    <td>{{ .StateHistory.LastState.Time.Local.Format "2006-01-02 15:04:05 MST" }}</td>
+                    <td>{{ $state.State.String | title }}</td>
+                    <td>{{ $state.Time.Local.Format "2006-01-02 15:04:05 MST" }}</td>
                     <td><code>{{ .Path }}</code></td>
                 </tr>
                 {{ end }}


### PR DESCRIPTION
This PR fixes an issue introduced by #122 where the return value of `State.LastState` was changed believing that I wasn't accessing the time field of the return value anywhere. This was however not the case. Some of the templates use this field. To get around the issue a couple of new methods were added to State and the templates updated accordingly.