### PR TITLE
feat: remove brief flag from runs

### DIFF
--- a/cmd/cleve/run/list.go
+++ b/cmd/cleve/run/list.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	csvOutput, jsonOutput, brief bool
-	platform, state              string
-	listCmd                      = &cobra.Command{
+	csvOutput, jsonOutput bool
+	platform, state       string
+	listCmd               = &cobra.Command{
 		Use:   "list",
 		Short: "List sequencing runs",
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -29,7 +29,6 @@ var (
 				log.Fatal(err)
 			}
 			filter := cleve.RunFilter{
-				Brief:    brief,
 				Platform: platform,
 				State:    state,
 			}
@@ -51,7 +50,6 @@ var (
 func init() {
 	listCmd.Flags().BoolVar(&csvOutput, "csv", false, "Output in CSV format")
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in CSV format")
-	listCmd.Flags().BoolVar(&brief, "brief", false, "Brief output")
 
 	listCmd.Flags().StringVar(&platform, "platform", "", "Filter by platform")
 	listCmd.Flags().StringVar(&state, "state", "", "Filter by state")

--- a/cmd/cleve/run/update.go
+++ b/cmd/cleve/run/update.go
@@ -48,7 +48,7 @@ var (
 			didSomething := false
 
 			var run *cleve.Run
-			run, err = db.Run(args[0], false)
+			run, err = db.Run(args[0])
 			if err != nil {
 				slog.Error("failed to fetch run information", "run", args[0], "error", err)
 			}

--- a/cmd/cleve/samplesheet/add.go
+++ b/cmd/cleve/samplesheet/add.go
@@ -42,7 +42,7 @@ var (
 				log.Fatal(err)
 			}
 
-			_, err = db.Run(runID, true)
+			_, err = db.Run(runID)
 			if err != nil {
 				if err == mongo.ErrNoDocuments {
 					log.Fatalf("error: run with id %q not found", runID)

--- a/filters.go
+++ b/filters.go
@@ -32,7 +32,6 @@ func (f PaginationFilter) Validate() error {
 type RunFilter struct {
 	RunID            string    `form:"run_id"`
 	RunIdQuery       string    `form:"run_id_query"`
-	Brief            bool      `form:"brief"`
 	Platform         string    `form:"platform"`
 	State            string    `form:"state"`
 	From             time.Time `form:"from"`

--- a/gin/dashboard.go
+++ b/gin/dashboard.go
@@ -160,7 +160,7 @@ func DashboardPanelHandler(db *mongo.DB) gin.HandlerFunc {
 func DashboardRunHandler(db *mongo.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		runId := c.Param("runId")
-		run, err := db.Run(runId, false)
+		run, err := db.Run(runId)
 		if err != nil {
 			if errors.Is(err, mongo.ErrNoDocuments) {
 				c.HTML(http.StatusNotFound, "error404", gin.H{"error": fmt.Sprintf("run with id %q not found", runId)})

--- a/gin/run_qc.go
+++ b/gin/run_qc.go
@@ -20,7 +20,7 @@ type RunQCGetter interface {
 
 // Interface for storing run QC data in the database.
 type RunQCSetter interface {
-	Run(string, bool) (*cleve.Run, error)
+	Run(string) (*cleve.Run, error)
 	CreateRunQC(string, interop.InteropSummary) error
 }
 
@@ -81,7 +81,7 @@ func AllRunQcHandler(db RunQCGetter) gin.HandlerFunc {
 func AddRunQcHandler(db RunQCGetterSetter) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		runId := ctx.Param("runId")
-		run, err := db.Run(runId, true)
+		run, err := db.Run(runId)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				ctx.AbortWithStatusJSON(

--- a/gin/runs.go
+++ b/gin/runs.go
@@ -15,7 +15,7 @@ import (
 
 // Interface for reading runs from the database.
 type RunGetter interface {
-	Run(string, bool) (*cleve.Run, error)
+	Run(string) (*cleve.Run, error)
 	Runs(cleve.RunFilter) (cleve.RunResult, error)
 }
 
@@ -53,8 +53,7 @@ func RunsHandler(db RunGetter) gin.HandlerFunc {
 func RunHandler(db RunGetter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		runId := c.Param("runId")
-		_, brief := c.GetQuery("brief")
-		run, err := db.Run(runId, brief)
+		run, err := db.Run(runId)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.JSON(http.StatusNotFound, gin.H{"error": "run not found"})
@@ -137,7 +136,7 @@ func UpdateRunHandler(db *mongo.DB) gin.HandlerFunc {
 			UpdateQc       bool   `json:"update_qc"`
 		}
 
-		run, err := db.Run(runId, false)
+		run, err := db.Run(runId)
 		if err != nil {
 			if errors.Is(err, mongo.ErrNoDocuments) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "run not found", "run_id": runId})

--- a/gin/runs_test.go
+++ b/gin/runs_test.go
@@ -91,29 +91,13 @@ func TestRunsHandler(t *testing.T) {
 			},
 		},
 		{
-			"brief",
-			cleve.RunResult{
-				Runs: []*cleve.Run{novaseq1, novaseq2, nextseq1},
-			},
-			nil,
-			"/api/runs?brief=true",
-			cleve.RunFilter{
-				Brief: true,
-				PaginationFilter: cleve.PaginationFilter{
-					Page:     1,
-					PageSize: 10,
-				},
-			},
-		},
-		{
-			"brief and platform filter",
+			"platform filter",
 			cleve.RunResult{
 				Runs: []*cleve.Run{novaseq1, novaseq2},
 			},
 			nil,
-			"/api/runs?brief=true&platform=NovaSeq",
+			"/api/runs?platform=NovaSeq",
 			cleve.RunFilter{
-				Brief:    true,
 				Platform: "NovaSeq",
 				PaginationFilter: cleve.PaginationFilter{
 					Page:     1,
@@ -127,9 +111,8 @@ func TestRunsHandler(t *testing.T) {
 				Runs: []*cleve.Run{novaseq1, novaseq2},
 			},
 			nil,
-			"/api/runs?brief=true&platform=NovaSeq&page=3&page_size=5",
+			"/api/runs?platform=NovaSeq&page=3&page_size=5",
 			cleve.RunFilter{
-				Brief:    true,
 				Platform: "NovaSeq",
 				PaginationFilter: cleve.PaginationFilter{
 					Page:     3,
@@ -143,9 +126,8 @@ func TestRunsHandler(t *testing.T) {
 				Runs: []*cleve.Run{},
 			},
 			nil,
-			"/api/runs?brief=true&platform=NovaSeq",
+			"/api/runs?platform=NovaSeq",
 			cleve.RunFilter{
-				Brief:    true,
 				Platform: "NovaSeq",
 				PaginationFilter: cleve.PaginationFilter{
 					Page:     1,
@@ -235,7 +217,6 @@ func TestRunHandler(t *testing.T) {
 			novaseq2,
 			gin.Params{
 				gin.Param{Key: "runId", Value: "run2"},
-				gin.Param{Key: "brief", Value: "false"},
 			},
 			http.StatusOK,
 			`"experiment_name":"experiment 3"`,
@@ -245,7 +226,6 @@ func TestRunHandler(t *testing.T) {
 			novaseq2,
 			gin.Params{
 				gin.Param{Key: "runId", Value: "run2"},
-				gin.Param{Key: "brief", Value: "true"},
 			},
 			http.StatusOK,
 			`"experiment_name":"experiment 3"`,
@@ -258,7 +238,7 @@ func TestRunHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 
-		rg.RunFn = func(run_id string, brief bool) (*cleve.Run, error) {
+		rg.RunFn = func(run_id string) (*cleve.Run, error) {
 			switch run_id {
 			case "run1":
 				return novaseq1, nil

--- a/mock/runs.go
+++ b/mock/runs.go
@@ -11,15 +11,15 @@ import (
 // the corresponding *Invoked fields register whether the function has been
 // called. The interface implementation then just wraps the *Fn functions.
 type RunGetter struct {
-	RunFn       func(string, bool) (*cleve.Run, error)
+	RunFn       func(string) (*cleve.Run, error)
 	RunInvoked  bool
 	RunsFn      func(cleve.RunFilter) (cleve.RunResult, error)
 	RunsInvoked bool
 }
 
-func (g *RunGetter) Run(id string, brief bool) (*cleve.Run, error) {
+func (g *RunGetter) Run(id string) (*cleve.Run, error) {
 	g.RunInvoked = true
-	return g.RunFn(id, brief)
+	return g.RunFn(id)
 }
 
 func (g *RunGetter) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {

--- a/mongo/runs.go
+++ b/mongo/runs.go
@@ -202,13 +202,6 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 		},
 	})
 
-	// Exclude run parameters
-	if filter.Brief {
-		pipeline = append(pipeline, bson.D{
-			{Key: "$unset", Value: bson.A{"run_parameters"}},
-		})
-	}
-
 	metaPipeline := append(pipeline, bson.D{
 		{Key: "$count", Value: "total_count"},
 	})
@@ -280,10 +273,9 @@ func (db DB) Runs(filter cleve.RunFilter) (cleve.RunResult, error) {
 	return r, nil
 }
 
-func (db DB) Run(runId string, brief bool) (*cleve.Run, error) {
+func (db DB) Run(runId string) (*cleve.Run, error) {
 	filter := cleve.RunFilter{
 		RunID: runId,
-		Brief: brief,
 	}
 	runs, err := db.Runs(filter)
 	if err != nil {


### PR DESCRIPTION
Now that the analyses are no longer part of the run documents, there is really no point in skipping any part of the document when requesting a run. Therefore the brief flag is removed from Cleve.

Merging this PR closes #127.