### PR TITLE
fix: better config file precedence rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ The resulting binary is `./bin/cleve`.
 Cleve looks for a yaml config file at startup.
 The following locations are checked in this order:
 
-- `/etc/cleve/config.yaml`
-- `$HOME/.config/cleve/config.yaml`
 - `$PWD/config.yaml`
+- `$XDG_CONFIG_HOME/cleve/config.yaml`
+- `$HOME/.config/cleve/config.yaml`
+- `/etc/cleve/config.yaml`
 
 The first config file that is found will be used, and the application will exit with an error if no config file is found.
 The config can also be supplied with the `-c`/`--config` flag.

--- a/cmd/cleve/main.go
+++ b/cmd/cleve/main.go
@@ -49,9 +49,13 @@ func initConfig() {
 	} else {
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
-		viper.AddConfigPath("/etc/cleve")
-		viper.AddConfigPath("$HOME/.config/cleve")
 		viper.AddConfigPath(".")
+		if _, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
+			viper.AddConfigPath("$XDG_CONFIG_HOME/cleve")
+		} else {
+			viper.AddConfigPath("$HOME/.config/cleve")
+		}
+		viper.AddConfigPath("/etc/cleve")
 	}
 
 	err := viper.ReadInConfig()


### PR DESCRIPTION
The new order is:

1. `$PWD/config.yaml`
2. `$XDG_CONFIG_HOME/cleve/config.yaml`
3. `$HOME/.config/cleve/config.yaml`
4. `/etc/cleve/config.yaml`

Closes #144 