### PR TITLE
feat: separate logging for watchers

### DIFF
--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -39,6 +40,19 @@ var (
 			if debug {
 				loglevel = slog.LevelDebug
 			}
+
+			watcherLogPath := viper.GetString("watcher_logfile")
+
+			var watcherLogWriter io.Writer
+			if watcherLogPath != "" {
+				f, err := os.OpenFile(watcherLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o666)
+				cobra.CheckErr(err)
+				watcherLogWriter = io.MultiWriter(os.Stderr, f)
+			} else {
+				watcherLogWriter = os.Stderr
+			}
+			watcherLogger := slog.New(slog.NewTextHandler(watcherLogWriter, &slog.HandlerOptions{Level: loglevel}))
+
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: loglevel}))
 			slog.SetDefault(logger)
 
@@ -47,7 +61,7 @@ var (
 				slog.Error("poll interval must be a positive, non-zero integer")
 				os.Exit(1)
 			}
-			runWatcher := watcher.NewRunWatcher(time.Duration(runPollInterval)*time.Second, db, logger)
+			runWatcher := watcher.NewRunWatcher(time.Duration(runPollInterval)*time.Second, db, watcherLogger.With("watcher", "RunWatcher"))
 			defer runWatcher.Stop()
 			runStateEvents := runWatcher.Start()
 
@@ -71,7 +85,7 @@ var (
 				slog.Error("poll interval must be a positive, non-zero integer")
 				os.Exit(1)
 			}
-			analysisWatcher := watcher.NewDragenAnalysisWatcher(time.Duration(analysisPollInterval)*time.Second, db, logger)
+			analysisWatcher := watcher.NewDragenAnalysisWatcher(time.Duration(analysisPollInterval)*time.Second, db, watcherLogger.With("watcher", "DragenAnalysisWatcher"))
 			defer analysisWatcher.Stop()
 			analysisEvents := analysisWatcher.Start()
 

--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -53,8 +53,7 @@ var (
 			}
 			watcherLogger := slog.New(slog.NewTextHandler(watcherLogWriter, &slog.HandlerOptions{Level: loglevel}))
 
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: loglevel}))
-			slog.SetDefault(logger)
+			logger := slog.Default()
 
 			runPollInterval := viper.GetInt("run_poll_interval")
 			if runPollInterval < 1 {

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ database:
 # If set, logs will be written to this file in addition to stdout
 # If not set, logs will only be written to stdout
 logfile: cleve.log
+watcher_logfile: cleve_watcher.log
 
 # How often, in seconds, that Cleve should poll runs and analyses
 # in the database for state changes. Setting this too low could


### PR DESCRIPTION
This PR sets up separate loggers for the watchers that are spun up when the server is started. It will write logs to the path defined by the config variable `watcher_logfile` and standard error. If the path is not defined, only stderr will be used. The loggers are set up to output the watcher that is logging, so logs from the watchers can potentially be made bit simpler by excluding this information.