### PR TITLE
fix: load QC data when run is ready

### DIFF
--- a/cmd/cleve/serve.go
+++ b/cmd/cleve/serve.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gmc-norr/cleve"
 	"github.com/gmc-norr/cleve/gin"
+	"github.com/gmc-norr/cleve/interop"
 	"github.com/gmc-norr/cleve/mongo"
 	"github.com/gmc-norr/cleve/watcher"
 	"github.com/spf13/cobra"
@@ -72,6 +73,16 @@ var (
 							slog.Info("updating run state", "run", e.Id, "path", e.Path, "state", e.State)
 							if err := db.SetRunState(e.Id, e.State); err != nil {
 								slog.Error("failed to update run state", "run", e.Id, "error", err)
+							}
+						}
+						if e.StateChanged && e.State == cleve.StateReady {
+							slog.Info("loading qc data", "run", e.Id)
+							qc, err := interop.InteropFromDir(e.Path)
+							if err != nil {
+								slog.Error("failed to read qc data", "run", e.Id, "error", err)
+							}
+							if err := db.UpdateRunQC(qc.Summarise()); err != nil {
+								slog.Error("failed to load qc data", "run", e.Id, "error", err)
 							}
 						}
 					}

--- a/mock/runs.go
+++ b/mock/runs.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"github.com/gmc-norr/cleve"
+	"github.com/gmc-norr/cleve/interop"
 	"github.com/gmc-norr/cleve/mongo"
 )
 
@@ -39,6 +40,8 @@ type RunSetter struct {
 	SetRunStateInvoked       bool
 	SetRunPathFn             func(string, string) error
 	SetRunPathInvoked        bool
+	UpdateRunQCFn            func(interop.InteropSummary) error
+	UpdateRunQCInvoked       bool
 }
 
 func (s *RunSetter) CreateRun(run *cleve.Run) error {
@@ -59,6 +62,11 @@ func (s *RunSetter) SetRunState(runId string, state cleve.State) error {
 func (s *RunSetter) SetRunPath(runId string, path string) error {
 	s.SetRunPathInvoked = true
 	return s.SetRunPathFn(runId, path)
+}
+
+func (s *RunSetter) UpdateRunQC(qc interop.InteropSummary) error {
+	s.UpdateRunQCInvoked = true
+	return s.UpdateRunQCFn(qc)
 }
 
 // Mock implementing the runHandler for RunWatcher


### PR DESCRIPTION
This now happens both when the state of a run changes to ready, and if a new run that already has a state of ready is added to the database.

It was said in #62 that issue #8 was closed, but this was apparently not entirely truthful. This should now have been addressed properly for the API endpoint.