### PR TITLE
fix: distinguish between missing and invalid file types

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -19,7 +19,8 @@ import (
 type AnalysisFileType int
 
 const (
-	_ AnalysisFileType = iota
+	_           AnalysisFileType = iota // Zero value
+	FileInvalid                         // Invalid value
 	FileVcf
 	FileBam
 	FileSnvVcf
@@ -61,13 +62,20 @@ func (t AnalysisFileType) String() string {
 }
 
 func (t AnalysisFileType) IsValid() bool {
-	return t > 0 && t <= FileInterop
+	return t > FileInvalid && t <= FileInterop
+}
+
+func (t AnalysisFileType) IsZero() bool {
+	return t == 0
 }
 
 func AnalysisFileTypeFromString(stringType string) AnalysisFileType {
+	if stringType == "" {
+		return 0
+	}
 	t, ok := validAnalysisFileTypes[stringType]
 	if !ok {
-		return 0
+		return FileInvalid
 	}
 	return t
 }

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -850,3 +850,49 @@ func TestBSONLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalysisFileType(t *testing.T) {
+	testcases := []struct {
+		name       string
+		typeString string
+		isValid    bool
+		isZero     bool
+	}{
+		{
+			name:       "fastq",
+			typeString: "fastq",
+			isValid:    true,
+			isZero:     false,
+		},
+		{
+			name:       "interop",
+			typeString: "interop",
+			isValid:    true,
+			isZero:     false,
+		},
+		{
+			name:       "empty",
+			typeString: "",
+			isValid:    false,
+			isZero:     true,
+		},
+		{
+			name:       "exe",
+			typeString: "exe",
+			isValid:    false,
+			isZero:     false,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			ft := AnalysisFileTypeFromString(c.typeString)
+			if ft.IsValid() != c.isValid {
+				t.Errorf("expected IsValid = %t, got %t", c.isValid, ft.IsValid())
+			}
+			if ft.IsZero() != c.isZero {
+				t.Errorf("expected IsZero = %t, got %t", c.isZero, ft.IsZero())
+			}
+		})
+	}
+}

--- a/filters.go
+++ b/filters.go
@@ -162,9 +162,12 @@ func NewAnalysisFileFilter() AnalysisFileFilter {
 
 func (f *AnalysisFileFilter) Validate() error {
 	var errs []error
-	if !f.FileType.IsValid() && f.ParentId == "" && f.Name == "" && f.Pattern == nil {
+	if f.FileType.IsZero() && f.ParentId == "" && f.Name == "" && f.Pattern == nil {
 		// for now, pattern is only for internal use
 		errs = append(errs, fmt.Errorf("one of type, parent id or name must be defined"))
+	}
+	if !f.FileType.IsZero() && !f.FileType.IsValid() {
+		errs = append(errs, fmt.Errorf("unsupported file type"))
 	}
 	if f.Pattern != nil && f.Name != "" {
 		errs = append(errs, fmt.Errorf("cannot use both name and pattern"))

--- a/filters_test.go
+++ b/filters_test.go
@@ -78,6 +78,31 @@ func TestAnalysisFileFilter(t *testing.T) {
 			},
 			isValid: false,
 		},
+		{
+			name: "invalid analysis file type",
+			filter: AnalysisFileFilter{
+				Level:    LevelSample,
+				FileType: AnalysisFileTypeFromString("blabla"),
+			},
+			isValid: false,
+		},
+		{
+			name: "valid filter with zero analysis file type",
+			filter: AnalysisFileFilter{
+				Level:    LevelSample,
+				ParentId: "sample1",
+			},
+			isValid: true,
+		},
+		{
+			name: "invalid file type",
+			filter: AnalysisFileFilter{
+				Level:    LevelSample,
+				FileType: AnalysisFileTypeFromString("blabla"),
+				ParentId: "sample1",
+			},
+			isValid: false,
+		},
 	}
 
 	for _, c := range testcases {


### PR DESCRIPTION
The goal of this PR is to distinguish between a missing file type for an analysis file filter and an invalid file type. Previously an invalid file could be caught in the filter validation and incorrectly state that required fields were missing, when in fact the required field (i.e. file type) was there, but was invalid. The zero value of an analysis file type is now not considered invalid, just missing, and actually invalid file types are correctly identified as such.