### PR TITLE
fix: address issues with nil webhook

### DIFF
--- a/cmd/cleve/run/add.go
+++ b/cmd/cleve/run/add.go
@@ -96,8 +96,10 @@ var addCmd = &cobra.Command{
 			}
 		}
 
-		if err := webhook.Send(cleve.NewRunMessage(&run, "new run added", cleve.MessageStateUpdate)); err != nil {
-			slog.Error("failed to send webhook message", "error", err)
+		if webhook != nil {
+			if err := webhook.Send(cleve.NewRunMessage(&run, "new run added", cleve.MessageStateUpdate)); err != nil {
+				slog.Error("failed to send webhook message", "error", err)
+			}
 		}
 
 		slog.Info("successfully added", "run", run.RunID)

--- a/gin/router.go
+++ b/gin/router.go
@@ -64,6 +64,10 @@ func authMiddleware(db *mongo.DB) gin.HandlerFunc {
 
 func webhookMiddleware(webhook *cleve.Webhook) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if webhook == nil {
+			c.Next()
+			return
+		}
 		rawSendMessage, ok := c.Keys["webhook_message"]
 		if !ok {
 			c.Next()


### PR DESCRIPTION
When adding a run from the CLI with no webhooks set up Cleve panics due to the webhook being `nil`. The same seems to be true for the API webhook middleware. This is now fixed by adding a guard.

Closes #180