### PR TITLE
fix: better representation of single-end indexes

### DIFF
--- a/gin/router.go
+++ b/gin/router.go
@@ -144,6 +144,10 @@ func title(s string) string {
 	return cases.Title(language.English).String(s)
 }
 
+func trimSuffix(s string, suffix string) string {
+	return strings.TrimSuffix(s, suffix)
+}
+
 func N(start, end int) chan int {
 	stream := make(chan int)
 	go func() {
@@ -200,6 +204,7 @@ func NewRouter(db *mongo.DB, debug bool, webhook *cleve.Webhook) http.Handler {
 		"multiply":    multiply,
 		"multiplyInt": multiplyInt,
 		"title":       title,
+		"trimSuffix":  trimSuffix,
 		"toFloat":     toFloat,
 		"isNaN":       math.IsNaN,
 		"N":           N,

--- a/templates/run.tmpl
+++ b/templates/run.tmpl
@@ -156,7 +156,7 @@
                     {{ range $s := .qc.IndexSummary.Indexes }}
                         <tr>
                             <td class="px-2">{{ $s.Sample }}</td>
-                            <td class="px-2 font-mono">{{ $s.Index }}</td>
+                            <td class="px-2 font-mono">{{ trimSuffix $s.Index "-" }}</td>
                             <td class="px-2 text-right">{{ toFloat $s.ReadCount | multiply 1e-6 | printf "%.2f" }}</td>
                             <td class="px-2 text-right">{{ $s.PercentReads | printf "%.2f" }}</td>
                         </tr>


### PR DESCRIPTION
Indexes for single-end sequencing showed up as `<index>-` in the index summary table. This PR adds a template function for trimming suffixes from strings, and this is then applied in the template to trim any trailing dashes from these indexes.