### PR TITLE
fix: allow analysis file duplicates if hashes are matching

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -711,18 +712,30 @@ func ReadDragenManifest(r io.Reader) (DragenManifest, error) {
 
 // FindFiles returns a list of paths where the file name (not the full path) matches the
 // supplied regular expression. If the regular expression is nil, or no files are found,
-// an empty slice is returned.
+// an empty slice is returned. If multiple files with the same base name and identical hashes
+// are found, only the first match will be in the resulting slice.
 func (m *DragenManifest) FindFiles(r *regexp.Regexp) []string {
-	var matches []string
+	var matches []ManifestFile
 	if r == nil {
-		return matches
+		return []string{}
 	}
 	for _, f := range m.Files {
 		if r.MatchString(filepath.Base(f.Name)) {
-			matches = append(matches, f.Name)
+			found := slices.ContainsFunc(matches, func(x ManifestFile) bool {
+				return filepath.Base(f.Name) == filepath.Base(x.Name) && f.Hash == x.Hash
+			})
+			if found {
+				// Ignore duplicates with the same base name and identical hash
+				continue
+			}
+			matches = append(matches, f)
 		}
 	}
-	return matches
+	filenames := make([]string, len(matches))
+	for i, mf := range matches {
+		filenames[i] = mf.Name
+	}
+	return filenames
 }
 
 // FindFile finds a single file whose base name matches the input name. A non-nil error

--- a/analysis.go
+++ b/analysis.go
@@ -667,7 +667,12 @@ func dragenAnalysisState(path string) State {
 }
 
 type DragenManifest struct {
-	Files []string
+	Files []ManifestFile
+}
+
+type ManifestFile struct {
+	Name string
+	Hash string
 }
 
 type DragenErrorSummary struct {
@@ -690,7 +695,7 @@ func ReadErrorSummary(r io.Reader) (DragenErrorSummary, error) {
 // ReadDragenManifest reads a Dragen analysis manifest file and returns a slice of
 // strings with all paths listed in the manifest.
 func ReadDragenManifest(r io.Reader) (DragenManifest, error) {
-	var files []string
+	var files []ManifestFile
 	csvReader := csv.NewReader(r)
 	csvReader.Comma = '\t'
 	csvReader.FieldsPerRecord = 2
@@ -699,7 +704,7 @@ func ReadDragenManifest(r io.Reader) (DragenManifest, error) {
 		return DragenManifest{}, err
 	}
 	for _, line := range lines {
-		files = append(files, line[0])
+		files = append(files, ManifestFile{Name: line[0], Hash: line[1]})
 	}
 	return DragenManifest{Files: files}, nil
 }
@@ -713,27 +718,29 @@ func (m *DragenManifest) FindFiles(r *regexp.Regexp) []string {
 		return matches
 	}
 	for _, f := range m.Files {
-		if r.MatchString(filepath.Base(f)) {
-			matches = append(matches, f)
+		if r.MatchString(filepath.Base(f.Name)) {
+			matches = append(matches, f.Name)
 		}
 	}
 	return matches
 }
 
 // FindFile finds a single file whose base name matches the input name. A non-nil error
-// is returned if more than one match is found, or if no matches are found.
+// is returned if more than one match is found and the hashes mismach, or if no
+// matches are found. If duplicates with the same hash are found, the last inspected
+// file will be returned.
 func (m *DragenManifest) FindFile(name string) (string, error) {
-	var foundFile string
+	var foundFile ManifestFile
 	for _, f := range m.Files {
-		if filepath.Base(f) == name {
-			if foundFile != "" {
-				return "", fmt.Errorf("more than one match found")
+		if filepath.Base(f.Name) == name {
+			if foundFile.Name != "" && foundFile.Hash != f.Hash {
+				return "", fmt.Errorf("more than one match found, and hashes are mismatching")
 			}
 			foundFile = f
 		}
 	}
-	if foundFile == "" {
+	if foundFile.Name == "" {
 		return "", fmt.Errorf("no matches found")
 	}
-	return foundFile, nil
+	return foundFile.Name, nil
 }

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -344,6 +344,23 @@ func TestDragenManifestFindFiles(t *testing.T) {
 			},
 		},
 		{
+			name: "duplicate file",
+			manifest: DragenManifest{
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash6"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
+				},
+			},
+			regex: regexp.MustCompile(`^file2.fastq.gz$`),
+			matches: []string{
+				"data/subdir2/file2.fastq.gz",
+			},
+		},
+		{
 			name: "nil regex",
 			manifest: DragenManifest{
 				Files: []ManifestFile{
@@ -357,7 +374,7 @@ func TestDragenManifestFindFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "no matcher",
+			name: "no matches",
 			manifest: DragenManifest{
 				Files: []ManifestFile{
 					{Name: "data/subdir1/file1.txt", Hash: "hash1"},

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -310,7 +310,7 @@ func TestDragenManifest(t *testing.T) {
 				t.Fatalf("expected %d files, got %d files", len(c.files), len(m.Files))
 			}
 			for i := range m.Files {
-				if m.Files[i] != c.files[i] {
+				if m.Files[i].Name != c.files[i] {
 					t.Errorf("expected file %d to be %s, got %s", i+1, c.files[i], m.Files[i])
 				}
 			}
@@ -328,13 +328,13 @@ func TestDragenManifestFindFiles(t *testing.T) {
 		{
 			name: "contains matches",
 			manifest: DragenManifest{
-				Files: []string{
-					"data/subdir1/file1.txt",
-					"data/subdir1/file1.fastq.gz",
-					"data/subdir2/file2.txt",
-					"data/subdir2/file2.fastq.gz",
-					"data/subdir2-1/file2.txt",
-					"data/subdir2-1/file2.fastq.gz",
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
 				},
 			},
 			regex: regexp.MustCompile(`^file2.fastq.gz$`),
@@ -346,26 +346,26 @@ func TestDragenManifestFindFiles(t *testing.T) {
 		{
 			name: "nil regex",
 			manifest: DragenManifest{
-				Files: []string{
-					"data/subdir1/file1.txt",
-					"data/subdir1/file1.fastq.gz",
-					"data/subdir2/file2.txt",
-					"data/subdir2/file2.fastq.gz",
-					"data/subdir2-1/file2.txt",
-					"data/subdir2-1/file2.fastq.gz",
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
 				},
 			},
 		},
 		{
 			name: "no matcher",
 			manifest: DragenManifest{
-				Files: []string{
-					"data/subdir1/file1.txt",
-					"data/subdir1/file1.fastq.gz",
-					"data/subdir2/file2.txt",
-					"data/subdir2/file2.fastq.gz",
-					"data/subdir2-1/file2.txt",
-					"data/subdir2-1/file2.fastq.gz",
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
 				},
 			},
 			regex: regexp.MustCompile(`^file3.fastq.gz$`),
@@ -396,30 +396,45 @@ func TestDragenManifestFindFile(t *testing.T) {
 		error     bool
 	}{
 		{
-			name: "multiple matches",
+			name: "multiple matches, mismatching hash",
 			manifest: DragenManifest{
-				Files: []string{
-					"data/subdir1/file1.txt",
-					"data/subdir1/file1.fastq.gz",
-					"data/subdir2/file2.txt",
-					"data/subdir2/file2.fastq.gz",
-					"data/subdir2-1/file2.txt",
-					"data/subdir2-1/file2.fastq.gz",
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
 				},
 			},
 			matchWith: "file2.txt",
 			error:     true,
 		},
 		{
+			name: "multiple matches, matching hash",
+			manifest: DragenManifest{
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash4"},
+				},
+			},
+			matchWith: "file2.txt",
+			match:     "data/subdir2-1/file2.txt",
+		},
+		{
 			name: "no matches",
 			manifest: DragenManifest{
-				Files: []string{
-					"data/subdir1/file1.txt",
-					"data/subdir1/file1.fastq.gz",
-					"data/subdir2/file2.txt",
-					"data/subdir2/file2.fastq.gz",
-					"data/subdir2-1/file2.txt",
-					"data/subdir2-1/file2.fastq.gz",
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
 				},
 			},
 			matchWith: "file3.txt",
@@ -428,13 +443,13 @@ func TestDragenManifestFindFile(t *testing.T) {
 		{
 			name: "single matches",
 			manifest: DragenManifest{
-				Files: []string{
-					"data/subdir1/file1.txt",
-					"data/subdir1/file1.fastq.gz",
-					"data/subdir2/file2.txt",
-					"data/subdir2/file2.fastq.gz",
-					"data/subdir2-1/file2.txt",
-					"data/subdir2-1/file2.fastq.gz",
+				Files: []ManifestFile{
+					{Name: "data/subdir1/file1.txt", Hash: "hash1"},
+					{Name: "data/subdir1/file1.fastq.gz", Hash: "hash2"},
+					{Name: "data/subdir2/file2.txt", Hash: "hash3"},
+					{Name: "data/subdir2/file2.fastq.gz", Hash: "hash4"},
+					{Name: "data/subdir2-1/file2.txt", Hash: "hash5"},
+					{Name: "data/subdir2-1/file2.fastq.gz", Hash: "hash6"},
 				},
 			},
 			matchWith: "file1.fastq.gz",


### PR DESCRIPTION
At least for MiSeq i100 there can be duplicates files in the manifest. I previously assumed that each filename would be unique in the manifest, but this is apparently not true. This PR addresses this by also checking the hash in the manifest and only returns an error if there are duplicate filenames and the hashes mismatch. If they are identical, the last observed file will be returned.