### PR TITLE
feat: remove gene panels from navigation menu

### DIFF
--- a/templates/header.tmpl
+++ b/templates/header.tmpl
@@ -13,7 +13,7 @@
             <ul class="list-none">
                 <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/runs">Runs</a></li>
                 <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/qc">QC</a></li>
-                <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/panels">Gene panels</a></li>
+                <!-- <li class="inline-block bg-accent-200 text-accent-900 mr-2 font-bold"><a class="px-4 py-2" href="/panels">Gene panels</a></li> -->
             </ul>
         </nav>
         {{ if .cleve_version }}


### PR DESCRIPTION
The gene panels should probably not be served here anyways, but for now I'm only removing the item from the navigation menu and not the whole implementation.